### PR TITLE
Trust nginx ingress

### DIFF
--- a/firefly-iii.yaml
+++ b/firefly-iii.yaml
@@ -81,6 +81,8 @@ spec:
             secretKeyRef:
               name: firefly-iii-secrets
               key: db_password
+        - name: TRUSTED_PROXIES
+          value: "**"
         ports:
         - containerPort: 80
           name: firefly-iii


### PR DESCRIPTION
This is needed to get https urls when running nginx ingress with cert-manager


@JC5
