### PR TITLE
Remove invalid whitespace

### DIFF
--- a/firefly-iii.yaml
+++ b/firefly-iii.yaml
@@ -38,7 +38,7 @@ spec:
   resources:
     requests:
       storage: 20Gi
---- 
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:


### PR DESCRIPTION
The extra whitespace in the YAML separator causes Kustomize to ignore the deployment object.


@JC5
