### PR TITLE
Updating yaml file for Kubernetes deployment

### DIFF
--- a/firefly-iii.yaml
+++ b/firefly-iii.yaml
@@ -1,4 +1,5 @@
-# Service to expose Firefly-III on port 80
+# Service to expose Firefly-III on an available port in Kubernetes cluster
+# Assigned port can be seen with `kubectl get services firefly-iii`
 
 apiVersion: v1
 kind: Service
@@ -7,13 +8,13 @@ metadata:
   labels:
     app: firefly-iii
 spec:
+  type: NodePort
   ports:
     - port: 80
       targetPort: 8080
   selector:
     app: firefly-iii
     tier: frontend
-  type: NodePort
 
 ---
 

--- a/firefly-iii.yaml
+++ b/firefly-iii.yaml
@@ -1,3 +1,5 @@
+# Service to expose Firefly-III on port 80
+
 apiVersion: v1
 kind: Service
 metadata:
@@ -12,20 +14,9 @@ spec:
     app: firefly-iii
     tier: frontend
   type: NodePort
+
 ---
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: firefly-iii-export-claim
-  labels:
-    app: firefly-iii
-spec:
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: 20Gi
----
+
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -38,7 +29,9 @@ spec:
   resources:
     requests:
       storage: 20Gi
+
 ---
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -88,15 +81,10 @@ spec:
         - containerPort: 8080
           name: firefly-iii
         volumeMounts:
-        - mountPath: "/var/www/firefly-iii/storage/export"
-          name: firefly-iii-export
         - mountPath: "/var/www/firefly-iii/storage/upload"
           name: firefly-iii-upload 
         imagePullPolicy: Always
       volumes:
-        - name: firefly-iii-export
-          persistentVolumeClaim:
-            claimName: firefly-iii-export-claim
         - name: firefly-iii-upload
           persistentVolumeClaim:
             claimName: firefly-iii-upload-claim

--- a/firefly-iii.yaml
+++ b/firefly-iii.yaml
@@ -11,7 +11,7 @@ spec:
   selector:
     app: firefly-iii
     tier: frontend
-  type: LoadBalancer
+  type: NodePort
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/firefly-iii.yaml
+++ b/firefly-iii.yaml
@@ -81,7 +81,7 @@ spec:
         - containerPort: 8080
           name: firefly-iii
         volumeMounts:
-        - mountPath: "/var/www/firefly-iii/storage/upload"
+        - mountPath: "/var/www/html/firefly-iii/storage/upload"
           name: firefly-iii-upload 
         imagePullPolicy: Always
       volumes:


### PR DESCRIPTION
Hello @JC5,

This fixes no known issue.

Changes in this pull request:
- Updating upload path from `/var/www/firefly-iii/storage/upload` to `/var/www/html/firefly-iii/storage/upload` as present in Docker image
- Removing export persistent volume claim directory and mounting
- Do some space (it was very condensed)
- Now we can directly access to Firefly-III on port 80

I getting in direction that you want to change your project directory from `/var/www/firefly-iii` to `/var/www/html/firefly-iii` in Docker images: your whole project is into this `html/` directory, but it's still existing a `storage` directory:

```
root@firefly-iii:/var/www# ls firefly-iii/ firefly-iii/storage/ html/
firefly-iii/:
storage

firefly-iii/storage/:
export	upload

html/:
COPYING  Procfile  app.json  bootstrap	   composer.json  config       database  index.php	 package.json  readme.md    resources  server.php		 storage  webpack.mix.js
LICENSE  app	   artisan   changelog.md  composer.lock  crowdin.yml  frontend  nginx_app.conf  public        releases.md  routes     sonar-project.properties  vendor   yarn.lock
```

Is that correct for you?

If yes, you won't have to maintain any path to those old directories anymore (`/var/www/firefly-iii` & sub). They can be deleted from other places in the project.

Tell me if you need any specific configuration for it, I'm a huge fan of your project, and according to [#Dockerfile](https://hub.docker.com/r/jc5x/firefly-iii) part, you can need some help to maintain this. If you're interested, contact me. I'll be more than happy to help you on those topics!

Best regards,

Pyrrha