### PR TITLE
Small fixes to run on current k8s

### DIFF
--- a/firefly-iii-csv.yaml
+++ b/firefly-iii-csv.yaml
@@ -1,0 +1,52 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: firefly-iii-csv
+  labels:
+    app: firefly-iii-csv
+spec:
+  clusterIP: None
+  ports:
+    - port: 8080
+  selector:
+    app: firefly-iii-csv
+    tier: frontend
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: firefly-iii-csv
+  labels:
+    app: firefly-iii-csv
+spec:
+  selector:
+    matchLabels:
+      app: firefly-iii-csv
+      tier: frontend
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: firefly-iii-csv
+        tier: frontend
+    spec:
+      containers:
+      - image: fireflyiii/csv-importer:version-2.5.0
+        name: firefly-iii-csv
+        env:
+        - name: FIREFLY_III_ACCESS_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: firefly-iii-secrets
+              key: access_token
+        - name: FIREFLY_III_URL
+          value: "http://firefly-iii:8080"
+        - name: TRUSTED_PROXIES
+          value: "**"
+        ports:
+        - containerPort: 8080
+          name: firefly-iii
+        imagePullPolicy: Always

--- a/firefly-iii.yaml
+++ b/firefly-iii.yaml
@@ -8,10 +8,9 @@ metadata:
   labels:
     app: firefly-iii
 spec:
-  type: NodePort
+  clusterIP: None
   ports:
-    - port: 80
-      targetPort: 8080
+    - port: 8080
   selector:
     app: firefly-iii
     tier: frontend

--- a/firefly-iii.yaml
+++ b/firefly-iii.yaml
@@ -28,7 +28,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 20Gi
+      storage: 10Gi
 
 ---
 

--- a/ingress-firefly-iii-csv.yaml
+++ b/ingress-firefly-iii-csv.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+#    kubernetes.io/tls-acme: "true"
+#    cert-manager.io/cluster-issuer: letsencrypt-prod
+    nginx.org/client-max-body-size: "0"
+    nginx.org/proxy-buffer-size: "8k"
+  labels:
+  name: firefly-iii-csv-ingress
+spec:
+  rules:
+  - host: csv-firefly-iii.your-domain.org
+    http:
+      paths:
+      - backend:
+          service:
+            name: firefly-iii-csv
+            port:
+              number: 8080
+        path: /
+        pathType: Prefix
+# tls:
+#  - hosts:
+#    - csv-firefly-iii.your-domain.org
+#    secretName: csv-firefly-iii.your-domain.org-tls
+

--- a/ingress-firefly-iii.yaml
+++ b/ingress-firefly-iii.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    #    kubernetes.io/tls-acme: "true"
+    #    cert-manager.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "16k"
+  labels:
+  name: firefly-iii-ingress
+spec:
+  rules:
+  - host: firefly-iii.your-domain.org
+    http:
+      paths:
+      - backend:
+          service:
+            name: firefly-iii
+            port:
+              number: 8080
+        path: /
+        pathType: Prefix
+#  tls:
+#  - hosts:
+#    - firefly-iii.your-domain.org
+#    secretName: firefly-iii.your-domain.org-tls
+

--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -1,8 +1,10 @@
 resources:
   - mysql.yaml
   - firefly-iii.yaml
+  - firefly-iii-csv.yaml
 secretGenerator:
 - name: firefly-iii-secrets
   literals:
   - db_password=CHANGEMECHANGEME
   - app_key=CHANGEMECHANGEMECHANGEMECHANGEME
+  - access_token=CHANGEMECHANGEMECHANGEME...

--- a/mysql.yaml
+++ b/mysql.yaml
@@ -45,7 +45,7 @@ spec:
         tier: mysql
     spec:
       containers:
-      - image: mysql:5.6
+      - image: yobasystems/alpine-mariadb:latest
         name: mysql
         env:
         - name: MYSQL_ROOT_PASSWORD

--- a/pv-firefly-iii-mysql.yaml.example
+++ b/pv-firefly-iii-mysql.yaml.example
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: data-firefly-iii-mysql
+spec:
+  capacity:
+    storage: 20Gi
+  volumeMode: Filesystem
+  accessModes:
+  - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Delete
+  storageClassName: local-storage
+  local:
+    path: /mnt/data/firefly-iii-mysql
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          - kube1

--- a/pv-firefly-iii.yaml.example
+++ b/pv-firefly-iii.yaml.example
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: data-firefly-iii
+spec:
+  capacity:
+    storage: 10Gi
+  volumeMode: Filesystem
+  accessModes:
+  - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Delete
+  storageClassName: local-storage
+  local:
+    path: /mnt/data/firefly-iii
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          - kube1


### PR DESCRIPTION
Changes in this pull request:

- added csv-importer pod
- added ingress (tls) support
- switched to latest alpine based mariadb
- added (example) definitions for persistent volumes.

@JC5
