### PR TITLE
replace csv samples with new data importer

### DIFF
--- a/firefly-iii-importer.yaml
+++ b/firefly-iii-importer.yaml
@@ -1,15 +1,15 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: firefly-iii-csv
+  name: firefly-iii-importer
   labels:
-    app: firefly-iii-csv
+    app: firefly-iii-importer
 spec:
   clusterIP: None
   ports:
     - port: 8080
   selector:
-    app: firefly-iii-csv
+    app: firefly-iii-importer
     tier: frontend
 
 ---
@@ -17,25 +17,25 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: firefly-iii-csv
+  name: firefly-iii-importer
   labels:
-    app: firefly-iii-csv
+    app: firefly-iii-importer
 spec:
   selector:
     matchLabels:
-      app: firefly-iii-csv
+      app: firefly-iii-importer
       tier: frontend
   strategy:
     type: Recreate
   template:
     metadata:
       labels:
-        app: firefly-iii-csv
+        app: firefly-iii-importer
         tier: frontend
     spec:
       containers:
-      - image: fireflyiii/csv-importer:version-2.5.0
-        name: firefly-iii-csv
+      - image: fireflyiii/data-importer:version-0.5.0
+        name: firefly-iii-importer
         env:
         - name: FIREFLY_III_ACCESS_TOKEN
           valueFrom:

--- a/ingress-firefly-iii-importer.yaml
+++ b/ingress-firefly-iii-importer.yaml
@@ -7,21 +7,21 @@ metadata:
     nginx.org/client-max-body-size: "0"
     nginx.org/proxy-buffer-size: "8k"
   labels:
-  name: firefly-iii-csv-ingress
+  name: firefly-iii-importer-ingress
 spec:
   rules:
-  - host: csv-firefly-iii.your-domain.org
+  - host: importer-firefly-iii.your-domain.org
     http:
       paths:
       - backend:
           service:
-            name: firefly-iii-csv
+            name: firefly-iii-importer
             port:
               number: 8080
         path: /
         pathType: Prefix
 # tls:
 #  - hosts:
-#    - csv-firefly-iii.your-domain.org
-#    secretName: csv-firefly-iii.your-domain.org-tls
+#    - importer-firefly-iii.your-domain.org
+#    secretName: importer-firefly-iii.your-domain.org-tls
 


### PR DESCRIPTION
Changes in this pull request:

- The CSV Importer has been archived (https://github.com/firefly-iii/csv-importer) and replaced by the Data Importer. This PR updates the k8s manifests accordingly.

@JC5
