### PR TITLE
Update helm chart 

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,14 +1,17 @@
 apiVersion: v2
 name: firefly
 description: Installs firefly-iii stack (db, app, csv importer)
-version: 0.0.2
+version: 0.0.3
 dependencies:
 - name: firefly-db
   version: 0.0.2
+  condition: firefly-db.enabled
   repository: "file://../firefly-db"
 - name: firefly-iii
   version: 0.0.2
+  condition: firefly-iii.enabled
   repository: "file://../firefly-iii"
 - name: firefly-csv
   version: 0.0.2
+  condition: firefly-csv.enabled
   repository: "file://../firefly-csv"

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -8,10 +8,10 @@ dependencies:
   condition: firefly-db.enabled
   repository: "file://../firefly-db"
 - name: firefly-iii
-  version: 0.0.4
+  version: 0.0.5
   condition: firefly-iii.enabled
   repository: "file://../firefly-iii"
 - name: firefly-csv
-  version: 0.0.4
+  version: 0.0.5
   condition: firefly-csv.enabled
   repository: "file://../firefly-csv"

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -8,10 +8,10 @@ dependencies:
   condition: firefly-db.enabled
   repository: "file://../firefly-db"
 - name: firefly-iii
-  version: 0.0.2
+  version: 0.0.3
   condition: firefly-iii.enabled
   repository: "file://../firefly-iii"
 - name: firefly-csv
-  version: 0.0.2
+  version: 0.0.3
   condition: firefly-csv.enabled
   repository: "file://../firefly-csv"

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,17 +1,17 @@
 apiVersion: v2
 name: firefly
 description: Installs firefly-iii stack (db, app, csv importer)
-version: 0.0.3
+version: 0.0.4
 dependencies:
 - name: firefly-db
-  version: 0.0.2
+  version: 0.0.3
   condition: firefly-db.enabled
   repository: "file://../firefly-db"
 - name: firefly-iii
-  version: 0.0.3
+  version: 0.0.4
   condition: firefly-iii.enabled
   repository: "file://../firefly-iii"
 - name: firefly-csv
-  version: 0.0.3
+  version: 0.0.4
   condition: firefly-csv.enabled
   repository: "file://../firefly-csv"

--- a/helm/README.md
+++ b/helm/README.md
@@ -53,6 +53,28 @@ Each chart has a `Makefile` which is meant to make things easier and provides th
 ## Upgrading
 
 When a release introduces breaking changes, this section outlines the manual actions that need to be taken.
+
+### From 0.0.3 to 0.0.4
+
+The storage class and access modes have been changed to match more setups without the need for configuration. If you want to keep the old settings, set the following values:
+
+```yaml
+firefly-iii:
+  storage:
+    class: nfs-client
+    accessModes: ReadWriteMany
+
+firefly-csv:
+  storage:
+    class: nfs-client
+    accessModes: ReadWriteMany
+
+firefly-db:
+  storage:
+    class: nfs-client
+    accessModes: ReadWriteMany
+```
+
 ### From 0.0.2 to 0.0.3
 
 The `firefly-iii` and `firefly-csv` charts have been updated and now support configuring ingress annotations.

--- a/helm/README.md
+++ b/helm/README.md
@@ -5,7 +5,7 @@ Installs firefly-iii in kubernetes.
 Motivated by [Discussion 4778](https://github.com/firefly-iii/firefly-iii/discussions/4778) and [Issue 4266](https://github.com/firefly-iii/firefly-iii/issues/4266).
 
 > WORK IN PROGRESS!
-> At the moment this chart can be seen as a reference. 
+> At the moment this chart can be seen as a reference.
 > Please read the discussion above for detailed information
 
 ## Anatomy
@@ -49,3 +49,27 @@ Each chart has a `Makefile` which is meant to make things easier and provides th
 `make upgrade`: upgrades your production firefly instance by performing `helm upgrade`. For this you need a `my.local.values.yaml`
 
 `make teardown`: deletes your production firefly instance.
+
+## Upgrading
+
+When a release introduces breaking changes, this section outlines the manual actions that need to be taken.
+### From 0.0.2 to 0.0.3
+
+The `firefly-iii` and `firefly-csv` charts have been updated and now support configuring ingress annotations.
+
+To keep the old annotations, add the following values:
+
+```yaml
+firefly-iii:
+  ingress:
+    annotations:
+      kubernetes.io/ingress.class: "nginx"
+      nginx.ingress.kubernetes.io/proxy-buffer-size: "16k"
+
+firefly-csv:
+  ingress:
+    annotations:
+      kubernetes.io/ingress.class: "nginx"
+      nginx.org/client-max-body-size: "0"
+      nginx.ingress.kubernetes.io/proxy-buffer-size: "16k"
+```

--- a/helm/charts/firefly-csv/Chart.yaml
+++ b/helm/charts/firefly-csv/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: firefly-csv
 description: Installs firefly's csv importer
-version: 0.0.2
+version: 0.0.3

--- a/helm/charts/firefly-csv/Chart.yaml
+++ b/helm/charts/firefly-csv/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: firefly-csv
 description: Installs firefly's csv importer
-version: 0.0.3
+version: 0.0.4

--- a/helm/charts/firefly-csv/Chart.yaml
+++ b/helm/charts/firefly-csv/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: firefly-csv
 description: Installs firefly's csv importer
-version: 0.0.4
+version: 0.0.5

--- a/helm/charts/firefly-csv/README.md
+++ b/helm/charts/firefly-csv/README.md
@@ -1,0 +1,19 @@
+# firefly-csv
+
+This chart installs the CSV importer for firefly
+
+## Upgrading
+
+When a release introduces breaking changes, this section outlines the manual actions that need to be taken.
+
+### From 0.0.2 to 0.0.3
+
+The Ingress annotations have been made configurable. To keep the annotations set in 0.0.2, add the following to your values:
+
+```yaml
+ingress:
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.org/client-max-body-size: "0"
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "16k"
+```

--- a/helm/charts/firefly-csv/README.md
+++ b/helm/charts/firefly-csv/README.md
@@ -6,6 +6,16 @@ This chart installs the CSV importer for firefly
 
 When a release introduces breaking changes, this section outlines the manual actions that need to be taken.
 
+### From 0.0.3 to 0.0.4
+
+The storage class and access modes have been changed to match more setups without the need for configuration. If you want to keep the old settings, set the following values:
+
+```yaml
+storage:
+  class: nfs-client
+  accessModes: ReadWriteMany
+```
+
 ### From 0.0.2 to 0.0.3
 
 The Ingress annotations have been made configurable. To keep the annotations set in 0.0.2, add the following to your values:

--- a/helm/charts/firefly-csv/templates/firefly-csv-ing.yaml
+++ b/helm/charts/firefly-csv/templates/firefly-csv-ing.yaml
@@ -13,6 +13,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
   rules:
   - host: {{ .Values.hostName }}
     http:

--- a/helm/charts/firefly-csv/templates/firefly-csv-ing.yaml
+++ b/helm/charts/firefly-csv/templates/firefly-csv-ing.yaml
@@ -8,10 +8,10 @@ metadata:
     chart: {{ template "firefly-csv.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  {{- with .Values.ingress.annotations }}
   annotations:
-    kubernetes.io/ingress.class: "nginx"
-    nginx.org/client-max-body-size: "0"
-    nginx.ingress.kubernetes.io/proxy-buffer-size: "16k"
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   rules:
   - host: {{ .Values.hostName }}

--- a/helm/charts/firefly-csv/templates/firefly-csv-pvc.yml
+++ b/helm/charts/firefly-csv/templates/firefly-csv-pvc.yml
@@ -4,7 +4,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ template "firefly-csv.fullname" . }}-pvc
 spec:
-  storageClassName: {{ .Values.storage.class }}
+  {{- with .Values.storage.class }}
+  storageClassName: {{ . }}
+  {{- end }}
   accessModes:
     - {{ .Values.storage.accessModes }}
   resources:

--- a/helm/charts/firefly-csv/values.yaml
+++ b/helm/charts/firefly-csv/values.yaml
@@ -7,8 +7,8 @@ ingress:
   annotations: {}
 
 storage:
-  class: nfs-client
-  accessModes: ReadWriteMany
+  class: ~
+  accessModes: ReadWriteOnce
   dataSize: 50Mi
 
 hostName: "csv.monkey.io"

--- a/helm/charts/firefly-csv/values.yaml
+++ b/helm/charts/firefly-csv/values.yaml
@@ -3,6 +3,9 @@ image:
   tag: version-2.6.0
   pullPolicy: IfNotPresent
 
+ingress:
+  annotations: {}
+
 storage:
   class: nfs-client
   accessModes: ReadWriteMany

--- a/helm/charts/firefly-csv/values.yaml
+++ b/helm/charts/firefly-csv/values.yaml
@@ -13,6 +13,9 @@ storage:
 
 hostName: "csv.monkey.io"
 
+ingress:
+  className: ~
+
 configs:
   FIREFLY_III_CLIENT_ID: ""
   FIREFLY_III_URL: ""

--- a/helm/charts/firefly-db/Chart.yaml
+++ b/helm/charts/firefly-db/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: firefly-db
 description: Installs a postgres db for firefly
-version: 0.0.2
+version: 0.0.3

--- a/helm/charts/firefly-db/README.md
+++ b/helm/charts/firefly-db/README.md
@@ -1,12 +1,12 @@
-# firefly-iii
+# firefly-db
 
-This chart installs Firely III.
+This chart installs a database for firefly
 
 ## Upgrading
 
 When a release introduces breaking changes, this section outlines the manual actions that need to be taken.
 
-### From 0.0.3 to 0.0.4
+### From 0.0.2 to 0.0.3
 
 The storage class and access modes have been changed to match more setups without the need for configuration. If you want to keep the old settings, set the following values:
 
@@ -14,15 +14,4 @@ The storage class and access modes have been changed to match more setups withou
 storage:
   class: nfs-client
   accessModes: ReadWriteMany
-```
-
-### From 0.0.2 to 0.0.3
-
-The Ingress annotations have been made configurable. To keep the annotations set in 0.0.2, add the following to your values:
-
-```yaml
-ingress:
-  annotations:
-    kubernetes.io/ingress.class: "nginx"
-    nginx.ingress.kubernetes.io/proxy-buffer-size: "16k"
 ```

--- a/helm/charts/firefly-db/templates/firefly-db-pvc.yml
+++ b/helm/charts/firefly-db/templates/firefly-db-pvc.yml
@@ -9,7 +9,9 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  storageClassName: {{ .Values.storage.class }}
+  {{- with .Values.storage.class }}
+  storageClassName: {{ . }}
+  {{- end }}
   accessModes:
     - {{ .Values.storage.accessModes }}
   resources:

--- a/helm/charts/firefly-db/values.yaml
+++ b/helm/charts/firefly-db/values.yaml
@@ -4,8 +4,8 @@ image:
   pullPolicy: IfNotPresent
 
 storage:
-  class: nfs-client
-  accessModes: ReadWriteMany
+  class: ~
+  accessModes: ReadWriteOnce
   dataSize: 1Gi
 
 configs:

--- a/helm/charts/firefly-iii/Chart.yaml
+++ b/helm/charts/firefly-iii/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: firefly-iii
 description: Installs firefly-iii
-version: 0.0.4
+version: 0.0.5

--- a/helm/charts/firefly-iii/Chart.yaml
+++ b/helm/charts/firefly-iii/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: firefly-iii
 description: Installs firefly-iii
-version: 0.0.2
+version: 0.0.3

--- a/helm/charts/firefly-iii/Chart.yaml
+++ b/helm/charts/firefly-iii/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: firefly-iii
 description: Installs firefly-iii
-version: 0.0.3
+version: 0.0.4

--- a/helm/charts/firefly-iii/README.md
+++ b/helm/charts/firefly-iii/README.md
@@ -1,0 +1,18 @@
+# firefly-iii
+
+This chart installs Firely III.
+
+## Upgrading
+
+When a release introduces breaking changes, this section outlines the manual actions that need to be taken.
+
+### From 0.0.2 to 0.0.3
+
+The Ingress annotations have been made configurable. To keep the annotations set in 0.0.2, add the following to your values:
+
+```yaml
+ingress:
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "16k"
+```

--- a/helm/charts/firefly-iii/templates/firefly-iii-ing.yaml
+++ b/helm/charts/firefly-iii/templates/firefly-iii-ing.yaml
@@ -8,9 +8,10 @@ metadata:
     chart: {{ template "firefly-iii.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  {{- with .Values.ingress.annotations }}
   annotations:
-    kubernetes.io/ingress.class: "nginx"
-    nginx.ingress.kubernetes.io/proxy-buffer-size: "16k"
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   rules:
   - host: {{ .Values.hostName }}

--- a/helm/charts/firefly-iii/templates/firefly-iii-ing.yaml
+++ b/helm/charts/firefly-iii/templates/firefly-iii-ing.yaml
@@ -13,6 +13,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
   rules:
   - host: {{ .Values.hostName }}
     http:

--- a/helm/charts/firefly-iii/templates/firefly-iii-pvc.yaml
+++ b/helm/charts/firefly-iii/templates/firefly-iii-pvc.yaml
@@ -9,7 +9,9 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  storageClassName: {{ .Values.storage.class }}
+  {{- with .Values.storage.class }}
+  storageClassName: {{ . }}
+  {{- end }}
   accessModes:
     - {{ .Values.storage.accessModes }}
   resources:

--- a/helm/charts/firefly-iii/values.yaml
+++ b/helm/charts/firefly-iii/values.yaml
@@ -5,6 +5,7 @@ image:
 
 ingress:
   annotations: {}
+  className: ~
 
 storage:
   class: ~

--- a/helm/charts/firefly-iii/values.yaml
+++ b/helm/charts/firefly-iii/values.yaml
@@ -3,6 +3,9 @@ image:
   tag: version-5.5.13
   pullPolicy: IfNotPresent
 
+ingress:
+  annotations: {}
+
 storage:
   class: nfs-client
   accessModes: ReadWriteMany

--- a/helm/charts/firefly-iii/values.yaml
+++ b/helm/charts/firefly-iii/values.yaml
@@ -7,8 +7,8 @@ ingress:
   annotations: {}
 
 storage:
-  class: nfs-client
-  accessModes: ReadWriteMany
+  class: ~
+  accessModes: ReadWriteOnce
   dataSize: 1Gi
 
 configs:


### PR DESCRIPTION
This is the first PR in a series of PRs to bring the helm charts up to version 1.0.0

Changes are explained in more detail in the commit message if needed.

For the `firefly-csv` chart, I'm aware that it needs to be updated for the importer. This will happen in one of the next PRs.

Changes in this pull request:

- fix: subcharts are only used when they are enabled in the config
- breaking feature change: ingress annotations are configurable now (this is needed to make the chart usable in some environments, e.g. cert-manager issuer annotations)
- breaking feature change: update storage class and access mode to more widely used values.
- feat: add support for `ingress.spec.ingressClassName` 

@JC5
