### PR TITLE
chore: switch to packaged dependencies

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -4,6 +4,21 @@
 
 Installs Firefly III in kubernetes.
 
+## Installation
+
+Add the helm repository with
+
+```sh
+helm repo add firefly-iii https://firefly-iii.github.io/kubernetes
+helm repo update
+```
+
+The charts are then usable as e.g. `firefly-iii/firefly-iii-stack`:
+
+```sh
+helm install firefly-iii firefly-iii/firefly-iii-stack
+```
+
 ## Anatomy
 
 This chart repository contains four charts:

--- a/charts/firefly-iii-stack/Chart.yaml
+++ b/charts/firefly-iii-stack/Chart.yaml
@@ -1,17 +1,17 @@
 apiVersion: v2
 name: firefly-iii-stack
 description: Installs Firefly III stack (db, app, importer)
-version: 0.3.0
+version: 0.4.0
 dependencies:
 - name: firefly-db
   version: 0.0.3
   condition: firefly-db.enabled
-  repository: "file://../firefly-db"
+  repository:  https://firefly-iii.github.io/kubernetes
 - name: firefly-iii
   version: 1.0.0
   condition: firefly-iii.enabled
-  repository: "file://../firefly-iii"
+  repository: https://firefly-iii.github.io/kubernetes
 - name: importer
   version: 1.1.0
   condition: importer.enabled
-  repository: "file://../importer"
+  repository: https://firefly-iii.github.io/kubernetes


### PR DESCRIPTION
:warning: #20 must be merged before this PR is merged!

This updates the URLs of the dependencies to the ones that are available after the merge of #20, eliminating the need to clone the repository to use the charts.

@JC5
