### PR TITLE
chore: bump versions and revert to local files

### DIFF
--- a/charts/firefly-db/Chart.yaml
+++ b/charts/firefly-db/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: firefly-db
 description: Installs a postgres db for Firefly III
-version: 0.0.3
+version: 0.0.4

--- a/charts/firefly-iii-stack/Chart.yaml
+++ b/charts/firefly-iii-stack/Chart.yaml
@@ -1,17 +1,17 @@
 apiVersion: v2
 name: firefly-iii-stack
 description: Installs Firefly III stack (db, app, importer)
-version: 0.4.0
+version: 0.4.1
 dependencies:
 - name: firefly-db
-  version: 0.0.3
+  version: 0.0.4
   condition: firefly-db.enabled
-  repository:  https://firefly-iii.github.io/kubernetes
+  repository:  "file://../firefly-db"
 - name: firefly-iii
-  version: 1.0.0
+  version: 1.0.1
   condition: firefly-iii.enabled
-  repository: https://firefly-iii.github.io/kubernetes
+  repository: "file://../firefly-iii"
 - name: importer
-  version: 1.1.0
+  version: 1.1.1
   condition: importer.enabled
-  repository: https://firefly-iii.github.io/kubernetes
+  repository: "file://../importer"

--- a/charts/firefly-iii/Chart.yaml
+++ b/charts/firefly-iii/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: firefly-iii
 description: Installs Firefly III
 type: application
-version: 1.0.0
+version: 1.0.1

--- a/charts/importer/Chart.yaml
+++ b/charts/importer/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: importer
 description: Deploys the importer chart for Firefly III
 type: application
-version: 1.1.0
+version: 1.1.1


### PR DESCRIPTION
## Changes

This bumps the versions of all charts to trigger a new release and switches back to use the dependencies locally.

Once the pipeline has successfully released the new versions and created the `index.yaml` in the `gh-pages` branch, I'll add another PR to switch back to the upstream repository again.

## Why

In the first action run for #20 (https://github.com/firefly-iii/kubernetes/runs/5256468777?check_suite_focus=true), the charts were released (see e.g. [importer-1.1.0](https://github.com/firefly-iii/kubernetes/releases/tag/importer-1.1.0)), but as the `gh-pages` branch didn't exist, it could not push the `index.yaml` to the `gh-pages` branch.

The re-run (https://github.com/firefly-iii/kubernetes/runs/5258243083?check_suite_focus=true) then checked the current chart versions against the existing releases - as they matched, nothing needed to be done.

#21 introduced the switch to use the helm repository that should've existed after the merge of #20 (the repository is described by the `index.yaml` file), but as there was no repository, it failed. 

@JC5
