### PR TITLE
chore: ignore Chart.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 # Helm packages
 *.tgz
+
+# Helm chart lock files - those would need manual updates.
+# As we have all charts in the same repository, we can assume trust between them
+Chart.lock


### PR DESCRIPTION
Changes in this pull request:

- git now ignores `Chart.lock` files that are generated during local testing. We can safely do so as we have to assume trust between the charts anyway as they are all in the same repository.

@JC5
