### PR TITLE
chore: switch to upstream dependencies

### DIFF
--- a/charts/firefly-iii-stack/Chart.yaml
+++ b/charts/firefly-iii-stack/Chart.yaml
@@ -1,17 +1,17 @@
 apiVersion: v2
 name: firefly-iii-stack
 description: Installs Firefly III stack (db, app, importer)
-version: 0.4.1
+version: 0.5.0
 dependencies:
 - name: firefly-db
   version: 0.0.4
   condition: firefly-db.enabled
-  repository:  "file://../firefly-db"
+  repository: https://firefly-iii.github.io/kubernetes/
 - name: firefly-iii
   version: 1.0.1
   condition: firefly-iii.enabled
-  repository: "file://../firefly-iii"
+  repository: https://firefly-iii.github.io/kubernetes/
 - name: importer
   version: 1.1.1
   condition: importer.enabled
-  repository: "file://../importer"
+  repository: https://firefly-iii.github.io/kubernetes/

--- a/charts/firefly-iii-stack/README.md
+++ b/charts/firefly-iii-stack/README.md
@@ -6,6 +6,10 @@ Installs Firefly III in kubernetes, optionally with a database and the importer.
 
 When a release introduces breaking changes, this section outlines the manual actions that need to be taken.
 
+### From 0.4.0 to 0.5.0
+
+No breaking changes in this release, but you can now use the helm repository directly from https://firefly-iii.github.io/kubernetes/.
+
 ### From 0.1.0 to 0.2.0
 
 The **firefely** wrapper chart has been renamed to **firefly-iii-stack**. All charts are now contained directly in the `charts` directory, following best practices for chart repositories.


### PR DESCRIPTION
Follow up for #22.

Changes in this pull request:

This moves back to upstream versions of the dependencies. This decouples the charts so that we can develop them without breaking the `firefly-iii-stack` chart immediately.

@JC5
