### PR TITLE
test/docs/feat: add Metadata, automatic linting and versioning documentation

### DIFF
--- a/.github/workflows/lint-and-release.yml
+++ b/.github/workflows/lint-and-release.yml
@@ -1,12 +1,41 @@
-name: Release charts
+name: Lint and release charts
 
 on:
+  pull_request:
   push:
     branches:
       - main
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v1
+        with:
+          # renovate: datasource=github-releases depName=helm/helm
+          version: v3.8.0
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.10"
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.2.0
+
+      - name: Run chart-testing (lint)
+        run: ct lint --config ct.yaml
+
+
   release:
+    if: ${{ github.ref == 'refs/heads/main' }}
+    needs:
+      - lint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/charts/README.md
+++ b/charts/README.md
@@ -37,3 +37,15 @@ Note that if you use the firefly-iii-stack chart, you'll have to put the values 
 ## Development and testing
 
 For the firefly-iii-stack chart, you need to [override the chart dependencies locally](firefly-iii-stack/README.md#dependency-chart-overrides) to develop it on your machine.
+
+### Versioning
+
+Helm charts use semantic versioning. For the charts in this repository, we only use the `[MAJOR].[MINOR].[PATCH]` syntax without any pre-releases.
+
+Please bump as follows:
+
+* Major version for breaking changes (this includes updates of default values as users may need to manually update their values)
+* Minor version when you add features
+* Patch version for bug fixes and documentation updates
+
+For the automatic releasing and linting to work, do not manually update the `firefly-iii-stack` to use new dependency versions in the same PR as this will fail validation and releasing.

--- a/charts/firefly-db/Chart.yaml
+++ b/charts/firefly-db/Chart.yaml
@@ -1,4 +1,10 @@
 apiVersion: v2
 name: firefly-db
+version: 0.0.5
 description: Installs a postgres db for Firefly III
-version: 0.0.4
+type: application
+sources:
+  - https://github.com/firefly-iii/kubernetes/tree/main/charts/firefly-db
+maintainers:
+  - name: morre
+    email: firefly-iii@mor.re

--- a/charts/firefly-iii-stack/Chart.yaml
+++ b/charts/firefly-iii-stack/Chart.yaml
@@ -1,7 +1,8 @@
 apiVersion: v2
 name: firefly-iii-stack
+version: 0.5.1
 description: Installs Firefly III stack (db, app, importer)
-version: 0.5.0
+type: application
 dependencies:
 - name: firefly-db
   version: 0.0.4
@@ -15,3 +16,10 @@ dependencies:
   version: 1.1.1
   condition: importer.enabled
   repository: https://firefly-iii.github.io/kubernetes/
+home: https://github.com/firefly-iii/kubernetes
+sources:
+  - https://github.com/firefly-iii/kubernetes
+maintainers:
+  - name: morre
+    email: firefly-iii@mor.re
+icon: https://raw.githubusercontent.com/firefly-iii/firefly-iii/main/.github/assets/img/logo-small.png

--- a/charts/firefly-iii/Chart.yaml
+++ b/charts/firefly-iii/Chart.yaml
@@ -1,5 +1,12 @@
 apiVersion: v2
 name: firefly-iii
+version: 1.0.2
 description: Installs Firefly III
 type: application
-version: 1.0.1
+home: https://www.firefly-iii.org/
+sources:
+  - https://github.com/firefly-iii/firefly-iii/
+maintainers:
+  - name: morre
+    email: firefly-iii@mor.re
+icon: https://raw.githubusercontent.com/firefly-iii/firefly-iii/main/.github/assets/img/logo-small.png

--- a/charts/importer/Chart.yaml
+++ b/charts/importer/Chart.yaml
@@ -1,5 +1,12 @@
 apiVersion: v2
 name: importer
+version: 1.1.2
 description: Deploys the importer chart for Firefly III
 type: application
-version: 1.1.1
+home: https://www.firefly-iii.org/
+sources:
+  - https://github.com/firefly-iii/data-importer
+maintainers:
+  - name: morre
+    email: firefly-iii@mor.re
+icon: https://raw.githubusercontent.com/firefly-iii/firefly-iii/main/.github/assets/img/logo-small.png

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,0 +1,5 @@
+# See https://github.com/helm/chart-testing#configuration
+remote: origin
+target-branch: main
+chart-dirs:
+  - charts


### PR DESCRIPTION
Changes in this pull request:

- Adds metadata to all charts (for more information and to have a valid Chart.yaml)
- Uses the [`ct` tool](https://github.com/helm/chart-testing) to lint charts when they change. This also checks that chart versions are bumped when changes are introduced.
- Adds information about the versioning used

@JC5
