### PR TITLE
docs: add helm-docs

### DIFF
--- a/.github/workflows/helm-docs.yml
+++ b/.github/workflows/helm-docs.yml
@@ -1,0 +1,25 @@
+name: Helm Docs
+
+on:
+  push:
+   
+jobs:
+  helm-docs:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-go@v2
+      with:
+        # renovate: go-version
+        go-version: 1.17.3
+
+    - name: Install helm-docs
+      run: go install github.com/norwoodj/helm-docs/cmd/helm-docs@latest
+
+    - name: regenerate documentation
+      run: $HOME/go/bin/helm-docs
+
+    - name: Commit updated docs
+      uses: EndBug/add-and-commit@v8
+      with:
+        message: 'docs: regenerate chart README.md'

--- a/charts/README.md
+++ b/charts/README.md
@@ -38,6 +38,10 @@ Note that if you use the firefly-iii-stack chart, you'll have to put the values 
 
 For the firefly-iii-stack chart, you need to [override the chart dependencies locally](firefly-iii-stack/README.md#dependency-chart-overrides) to develop it on your machine.
 
+Please document values with `# -- <Documentation here>` comments so that helm-docs can automatically pick them up for the README.
+
+When introducing breaking changes, please document them in the `README.md.gotmpl` file of the respective chart.
+
 ### Versioning
 
 Helm charts use semantic versioning. For the charts in this repository, we only use the `[MAJOR].[MINOR].[PATCH]` syntax without any pre-releases.

--- a/charts/firefly-db/Chart.yaml
+++ b/charts/firefly-db/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: firefly-db
-version: 0.0.5
+version: 0.0.6
 description: Installs a postgres db for Firefly III
 type: application
 sources:

--- a/charts/firefly-db/README.md
+++ b/charts/firefly-db/README.md
@@ -1,6 +1,8 @@
 # firefly-db
 
-This chart installs a database for Firefly III
+![Version: 0.0.4](https://img.shields.io/badge/Version-0.0.4-informational?style=flat-square)
+
+Installs a postgres db for Firefly III
 
 ## Upgrading
 
@@ -15,3 +17,26 @@ storage:
   class: nfs-client
   accessModes: ReadWriteMany
 ```
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| backupSchedule | string | `"0 3 * * *"` |  |
+| configs.BACKUP_URL | string | `""` |  |
+| configs.DBHOST | string | `"firefly-firefly-db"` |  |
+| configs.DBNAME | string | `"firefly"` |  |
+| configs.DBPORT | string | `"5432"` |  |
+| configs.DBUSER | string | `"firefly"` |  |
+| configs.PGPASSWORD | string | `""` |  |
+| configs.POSTGRES_HOST_AUTH_METHOD | string | `"trust"` |  |
+| configs.POSTGRES_PASSWORD | string | `""` |  |
+| configs.POSTGRES_USER | string | `"firefly"` |  |
+| configs.RESTORE_URL | string | `""` |  |
+| configs.TZ | string | `"Europe/Amsterdan"` |  |
+| image.pullPolicy | string | `"IfNotPresent"` |  |
+| image.repository | string | `"postgres"` |  |
+| image.tag | string | `"10-alpine"` |  |
+| storage.accessModes | string | `"ReadWriteOnce"` |  |
+| storage.class | string | `nil` |  |
+| storage.dataSize | string | `"1Gi"` |  |

--- a/charts/firefly-db/README.md
+++ b/charts/firefly-db/README.md
@@ -1,8 +1,17 @@
 # firefly-db
 
-![Version: 0.0.4](https://img.shields.io/badge/Version-0.0.4-informational?style=flat-square)
+![Version: 0.0.6](https://img.shields.io/badge/Version-0.0.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Installs a postgres db for Firefly III
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| morre | firefly-iii@mor.re |  |
+## Source Code
+
+* <https://github.com/firefly-iii/kubernetes/tree/main/charts/firefly-db>
 
 ## Upgrading
 

--- a/charts/firefly-db/README.md.gotmpl
+++ b/charts/firefly-db/README.md.gotmpl
@@ -1,0 +1,25 @@
+{{ template "chart.header" . }}
+{{ template "chart.deprecationWarning" . }}
+{{ template "chart.badgesSection" . }}
+
+{{ template "chart.description" . }}
+{{ template "chart.homepageLine" . }}
+{{ template "chart.maintainersSection" . }}
+{{ template "chart.sourcesSection" . }}
+{{ template "chart.requirementsSection" . }}
+
+## Upgrading
+
+When a release introduces breaking changes, this section outlines the manual actions that need to be taken.
+
+### From 0.0.2 to 0.0.3
+
+The storage class and access modes have been changed to match more setups without the need for configuration. If you want to keep the old settings, set the following values:
+
+```yaml
+storage:
+  class: nfs-client
+  accessModes: ReadWriteMany
+```
+
+{{ template "chart.valuesSection" . }}

--- a/charts/firefly-iii-stack/Chart.yaml
+++ b/charts/firefly-iii-stack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: firefly-iii-stack
-version: 0.5.1
+version: 0.5.2
 description: Installs Firefly III stack (db, app, importer)
 type: application
 dependencies:

--- a/charts/firefly-iii-stack/README.md
+++ b/charts/firefly-iii-stack/README.md
@@ -1,9 +1,17 @@
 # firefly-iii-stack
 
-![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square)
+![Version: 0.5.2](https://img.shields.io/badge/Version-0.5.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Installs Firefly III stack (db, app, importer)
+**Homepage:** <https://github.com/firefly-iii/kubernetes>
+## Maintainers
 
+| Name | Email | Url |
+| ---- | ------ | --- |
+| morre | firefly-iii@mor.re |  |
+## Source Code
+
+* <https://github.com/firefly-iii/kubernetes>
 ## Requirements
 
 | Repository | Name | Version |

--- a/charts/firefly-iii-stack/README.md.gotmpl
+++ b/charts/firefly-iii-stack/README.md.gotmpl
@@ -1,16 +1,12 @@
-# firefly-iii-stack
+{{ template "chart.header" . }}
+{{ template "chart.deprecationWarning" . }}
+{{ template "chart.badgesSection" . }}
 
-![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square)
-
-Installs Firefly III stack (db, app, importer)
-
-## Requirements
-
-| Repository | Name | Version |
-|------------|------|---------|
-| https://firefly-iii.github.io/kubernetes/ | firefly-db | 0.0.4 |
-| https://firefly-iii.github.io/kubernetes/ | firefly-iii | 1.0.1 |
-| https://firefly-iii.github.io/kubernetes/ | importer | 1.1.1 |
+{{ template "chart.description" . }}
+{{ template "chart.homepageLine" . }}
+{{ template "chart.maintainersSection" . }}
+{{ template "chart.sourcesSection" . }}
+{{ template "chart.requirementsSection" . }}
 
 ## Upgrading
 
@@ -84,25 +80,4 @@ Therefore, you'll need to override the dependencies manually for local testing a
 
 For every dependency, replace `repository: https://firefly-iii.github.io/kubernetes/` with `repository: file://../${dependency_chart_name}`.
 
-## Values
-
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| firefly-db.backupSchedule | string | `"0 3 * * *"` |  |
-| firefly-db.configs.BACKUP_URL | string | `""` |  |
-| firefly-db.configs.DBHOST | string | `"firefly-firefly-db"` |  |
-| firefly-db.configs.DBNAME | string | `"firefly"` |  |
-| firefly-db.configs.DBPORT | string | `"5432"` |  |
-| firefly-db.configs.DBUSER | string | `"firefly"` |  |
-| firefly-db.configs.PGPASSWORD | string | `"YOURDBPASSWORD"` |  |
-| firefly-db.configs.RESTORE_URL | string | `""` |  |
-| firefly-db.configs.TZ | string | `"Europe/Berlin"` |  |
-| firefly-db.enabled | bool | `true` |  |
-| firefly-db.image.pullPolicy | string | `"IfNotPresent"` |  |
-| firefly-db.image.repository | string | `"postgres"` |  |
-| firefly-db.image.tag | string | `"10-alpine"` |  |
-| firefly-db.storage.accessModes | string | `"ReadWriteMany"` |  |
-| firefly-db.storage.class | string | `"nfs-client"` |  |
-| firefly-db.storage.dataSize | string | `"1Gi"` |  |
-| firefly-iii.enabled | bool | `true` | Set to false to not deploy Firefly III |
-| importer.enabled | bool | `true` | Set to false to not deploy the importer |
+{{ template "chart.valuesSection" . }}

--- a/charts/firefly-iii/Chart.yaml
+++ b/charts/firefly-iii/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: firefly-iii
-version: 1.0.2
+version: 1.0.3
 description: Installs Firefly III
 type: application
 home: https://www.firefly-iii.org/

--- a/charts/firefly-iii/README.md
+++ b/charts/firefly-iii/README.md
@@ -1,6 +1,8 @@
 # firefly-iii
 
-This chart installs Firefly III.
+![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+
+Installs Firefly III
 
 ## Upgrading
 
@@ -58,3 +60,50 @@ ingress:
     kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/proxy-buffer-size: "16k"
 ```
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` |  |
+| autoscaling.enabled | bool | `false` |  |
+| autoscaling.maxReplicas | int | `100` |  |
+| autoscaling.minReplicas | int | `1` |  |
+| autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
+| config | object | `{"env":{"DB_CONNECTION":"pgsql","DB_DATABASE":"firefly","DB_PORT":"5432","DB_USERNAME":"firefly","DEFAULT_LANGUAGE":"en_US","DEFAULT_LOCALE":"equal","TRUSTED_PROXIES":"**","TZ":"Europe/Amsterdam"},"existingSecret":""}` | Environment variables for Firefly III. See docs at: https://github.com/firefly-iii/firefly-iii/blob/main/.env.example |
+| config.env | object | `{"DB_CONNECTION":"pgsql","DB_DATABASE":"firefly","DB_PORT":"5432","DB_USERNAME":"firefly","DEFAULT_LANGUAGE":"en_US","DEFAULT_LOCALE":"equal","TRUSTED_PROXIES":"**","TZ":"Europe/Amsterdam"}` | Directly defined environment variables. Use this for non-secret configuration values. |
+| config.existingSecret | string | `""` | Set this to the name of a secret to load environment variables from. If defined, values in the secret will override values in config.env |
+| cronjob | object | `{"affinity":{},"annotations":{},"auth":{"existingSecret":"","token":""},"enabled":false,"failedJobsHistoryLimit":1,"image":{"pullPolicy":"IfNotPresent","repository":"curlimages/curl","tag":"7.81.0"},"imagePullSecrets":[],"nodeSelector":{},"podAnnotations":{},"podSecurityContext":{},"resources":{},"restartPolicy":"OnFailure","schedule":"0 3 * * *","securityContext":{},"successfulJobsHistoryLimit":3,"tolerations":[]}` | A cronjob for [recurring Firefly III tasks](https://docs.firefly-iii.org/firefly-iii/advanced-installation/cron/). |
+| cronjob.annotations | object | `{}` | Annotations for the CronJob |
+| cronjob.auth | object | `{"existingSecret":"","token":""}` | Authorization for the CronJob. See https://docs.firefly-iii.org/firefly-iii/advanced-installation/cron/#request-a-page-over-the-web |
+| cronjob.auth.existingSecret | string | `""` | The name of a secret containing a data.token field with the cronjob token |
+| cronjob.auth.token | string | `""` | The token in plain text |
+| cronjob.enabled | bool | `false` | Set to true to enable the CronJob. Note that you need to specify either cronjob.auth.existingSecret or cronjob.auth.token for it to actually be deployed. |
+| cronjob.failedJobsHistoryLimit | int | `1` | How many pods to keep around for failed jobs |
+| cronjob.restartPolicy | string | `"OnFailure"` | How to treat failed jobs |
+| cronjob.schedule | string | `"0 3 * * *"` | When to run the CronJob. Defaults to 03:00 as this is when Firefly III executes regular tasks. |
+| cronjob.successfulJobsHistoryLimit | int | `3` | How many pods to keep around for successful jobs |
+| fullnameOverride | string | `""` |  |
+| image.pullPolicy | string | `"IfNotPresent"` |  |
+| image.repository | string | `"fireflyiii/core"` |  |
+| image.tag | string | `"version-5.6.14"` |  |
+| imagePullSecrets | list | `[]` |  |
+| ingress.annotations | object | `{}` |  |
+| ingress.className | string | `""` |  |
+| ingress.enabled | bool | `false` |  |
+| ingress.hosts[0] | string | `"chart-example.local"` |  |
+| ingress.tls | list | `[]` |  |
+| nameOverride | string | `""` |  |
+| nodeSelector | object | `{}` |  |
+| persistence.accessModes | string | `"ReadWriteOnce"` |  |
+| persistence.class | string | `""` |  |
+| persistence.enabled | bool | `true` | If you set this to false, uploaded attachments are not stored persistently and will be lost with every restart of the pod |
+| persistence.storage | string | `"1Gi"` |  |
+| podAnnotations | object | `{}` |  |
+| podSecurityContext | object | `{}` |  |
+| replicaCount | int | `1` |  |
+| resources | object | `{}` |  |
+| securityContext | object | `{}` |  |
+| service.port | int | `80` |  |
+| service.type | string | `"ClusterIP"` |  |
+| tolerations | list | `[]` |  |

--- a/charts/firefly-iii/README.md
+++ b/charts/firefly-iii/README.md
@@ -1,8 +1,17 @@
 # firefly-iii
 
-![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 1.0.3](https://img.shields.io/badge/Version-1.0.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Installs Firefly III
+**Homepage:** <https://www.firefly-iii.org/>
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| morre | firefly-iii@mor.re |  |
+## Source Code
+
+* <https://github.com/firefly-iii/firefly-iii/>
 
 ## Upgrading
 

--- a/charts/firefly-iii/README.md.gotmpl
+++ b/charts/firefly-iii/README.md.gotmpl
@@ -1,0 +1,68 @@
+{{ template "chart.header" . }}
+{{ template "chart.deprecationWarning" . }}
+{{ template "chart.badgesSection" . }}
+
+{{ template "chart.description" . }}
+{{ template "chart.homepageLine" . }}
+{{ template "chart.maintainersSection" . }}
+{{ template "chart.sourcesSection" . }}
+{{ template "chart.requirementsSection" . }}
+
+## Upgrading
+
+When a release introduces breaking changes, this section outlines the manual actions that need to be taken.
+
+### From 0.0.4 to 1.0.0
+
+This version bump is a full rework of the chart to be in line with current helm best practices and to add configurability. See the subsections for all changes.
+
+A cronjob has been added to support [Firefly III features that need it](https://docs.firefly-iii.org/firefly-iii/advanced-installation/cron/). It is disabled by default, set `cronjob.enabled` to true to enable it. Please note that you need to specify `cronjob.auth.token` or `cronjob.auth.existingSecret` so that the job is actually deployed an can run. If you specify an existingSecret, it needs to have the token in the field `token`.
+
+#### Resources
+
+The PVC has been renamed. You therefore need to manually back up and restore the upload data or retain and reclaim the PV with the new PVC. As this is highly dependant on your Kubernetes distribution and provider, instructions for the latter can't be generalized.
+
+To backup and restore your files easily, use `kubectl cp $FIREFLY_POD_NAME:/var/www/html/firefly-iii/storage/upload $LOCAL_BACKUP_DIR`, apply the changes and then reverse the process by running `kubectl cp "${LOCAL_BACKUP_DIR}/*" $FIREFLY_POD_NAME:/var/www/html/firefly-iii/storage/upload/`.
+
+#### values.yaml
+
+The configuration has changed as follows:
+
+* `storage` has been moved to `persistence`. There's a new `persistence.enabled` value that is `true` by default.
+* `storage.dataSize` has been moved to `persistence.storage`.
+* `hostName` has moved to a list in `ingress.hosts`
+* The ingress is disabled by default. Set `ingress.enabled` to `true` to enable it
+* `configs` has moved to `config.env`
+* A new key `config.existingSecret` has been added. It references a secret where you can store Firefly III configuration environment variables. Environment variables specified in the secret override the ones in `config.env`.
+
+#### Labels
+
+The pod label keys have changed as follows:
+
+* `app` has been replaced by `app.kubernetes.io/name`
+* `chart` has been replaced by `helm.sh/chart`
+* `release` has been replaced by `app.kubernetes.io/instance`
+* `heritage` has been replaced by `app.kubernetes.io/managed-by`
+
+### From 0.0.3 to 0.0.4
+
+The storage class and access modes have been changed to match more setups without the need for configuration. If you want to keep the old settings, set the following values:
+
+```yaml
+storage:
+  class: nfs-client
+  accessModes: ReadWriteMany
+```
+
+### From 0.0.2 to 0.0.3
+
+The Ingress annotations have been made configurable. To keep the annotations set in 0.0.2, add the following to your values:
+
+```yaml
+ingress:
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "16k"
+```
+
+{{ template "chart.valuesSection" . }}

--- a/charts/importer/Chart.yaml
+++ b/charts/importer/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: importer
-version: 1.1.2
+version: 1.1.3
 description: Deploys the importer chart for Firefly III
 type: application
 home: https://www.firefly-iii.org/

--- a/charts/importer/README.md
+++ b/charts/importer/README.md
@@ -1,6 +1,8 @@
 # importer
 
-This chart installs the data importer for Firefly III.
+![Version: 1.1.1](https://img.shields.io/badge/Version-1.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+
+Deploys the importer chart for Firefly III
 
 ## Setup
 
@@ -17,3 +19,34 @@ When you set `fireflyiii.auth.accessToken`, be aware that this is a secret and s
 ## Upgrading
 
 When a release introduces breaking changes, this section outlines the manual actions that need to be taken.
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` |  |
+| fireflyiii.auth.accessToken | string | `""` | The access token in plain text |
+| fireflyiii.auth.existingSecret | string | `""` | If you specify an existingSecret, it has to have the accessToken in a .spec.data.accessToken |
+| fireflyiii.url | string | `"http://firefly-firefly-iii:80"` | The URL at which Firefly III is available. If you change this value, click the "Reauthenticate" button on the importer after opening it! |
+| fireflyiii.vanityUrl | string | `""` | The URL at which you access Firefly III. Check https://docs.firefly-iii.org/data-importer/install/configure/#configure-fidi to find out if you should set this. |
+| fullnameOverride | string | `""` |  |
+| image.pullPolicy | string | `"IfNotPresent"` |  |
+| image.repository | string | `"fireflyiii/data-importer"` |  |
+| image.tag | string | `"version-0.8.0"` |  |
+| imagePullSecrets | list | `[]` |  |
+| ingress.annotations | object | `{}` |  |
+| ingress.className | string | `""` |  |
+| ingress.enabled | bool | `false` |  |
+| ingress.hosts[0] | string | `"chart-example.local"` |  |
+| ingress.tls | list | `[]` |  |
+| nameOverride | string | `""` |  |
+| nodeSelector | object | `{}` |  |
+| podAnnotations | object | `{}` |  |
+| podSecurityContext | object | `{}` |  |
+| replicaCount | int | `1` |  |
+| resources | object | `{}` |  |
+| securityContext | object | `{}` |  |
+| service.port | int | `80` |  |
+| service.type | string | `"ClusterIP"` |  |
+| tolerations | list | `[]` |  |
+| trustedProxies | string | `"**"` | The proxies that are trusted by the importer |

--- a/charts/importer/README.md
+++ b/charts/importer/README.md
@@ -1,8 +1,17 @@
 # importer
 
-![Version: 1.1.1](https://img.shields.io/badge/Version-1.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 1.1.3](https://img.shields.io/badge/Version-1.1.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Deploys the importer chart for Firefly III
+**Homepage:** <https://www.firefly-iii.org/>
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| morre | firefly-iii@mor.re |  |
+## Source Code
+
+* <https://github.com/firefly-iii/data-importer>
 
 ## Setup
 

--- a/charts/importer/README.md.gotmpl
+++ b/charts/importer/README.md.gotmpl
@@ -1,0 +1,27 @@
+{{ template "chart.header" . }}
+{{ template "chart.deprecationWarning" . }}
+{{ template "chart.badgesSection" . }}
+
+{{ template "chart.description" . }}
+{{ template "chart.homepageLine" . }}
+{{ template "chart.maintainersSection" . }}
+{{ template "chart.sourcesSection" . }}
+{{ template "chart.requirementsSection" . }}
+
+## Setup
+
+:warning: When enabling the ingress, be aware that the importer does not have any authentication. You are responsible to configure authentication at the ingress level
+
+There are some values that you should check before installing this chart:
+
+* `trustedProxies` (default: `"**"`): The proxies that are trusted by the importer
+* `fireflyiii.url` (default: `"http://firefly-firefly-iii:8080"`): The URL at which Firefly III is available
+
+For authentication, use `fireflyiii.auth.existingSecret` if you have an existing Secret with `data.accessToken` specified.
+When you set `fireflyiii.auth.accessToken`, be aware that this is a secret and should not be commited to a repository.
+
+## Upgrading
+
+When a release introduces breaking changes, this section outlines the manual actions that need to be taken.
+
+{{ template "chart.valuesSection" . }}


### PR DESCRIPTION
Changes in this pull request:

This adds a `README.md.gotmpl` template for each chart and introduces a `Helm Docs` GitHub action that automatically regenerates documentation.

@JC5
