### PR TITLE
Allow using existing claims and secrets in db and main

### DIFF
--- a/charts/firefly-db/Chart.yaml
+++ b/charts/firefly-db/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: firefly-db
-version: 0.0.6
+version: 0.1.0
 description: Installs a postgres db for Firefly III
 type: application
 sources:

--- a/charts/firefly-db/README.md
+++ b/charts/firefly-db/README.md
@@ -1,6 +1,6 @@
 # firefly-db
 
-![Version: 0.0.6](https://img.shields.io/badge/Version-0.0.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Installs a postgres db for Firefly III
 
@@ -43,9 +43,11 @@ storage:
 | configs.POSTGRES_USER | string | `"firefly"` |  |
 | configs.RESTORE_URL | string | `""` |  |
 | configs.TZ | string | `"Europe/Amsterdan"` |  |
+| configs.existingSecret | string | `""` | Set this to the name of a secret to load environment variables from. If defined, values in the secret will override values in configs |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"postgres"` |  |
 | image.tag | string | `"10-alpine"` |  |
 | storage.accessModes | string | `"ReadWriteOnce"` |  |
 | storage.class | string | `nil` |  |
 | storage.dataSize | string | `"1Gi"` |  |
+| storage.existingClaim | string | `""` | Use an existing PersistentVolumeClaim, overrides values above |

--- a/charts/firefly-db/templates/firefly-db-deploy.yml
+++ b/charts/firefly-db/templates/firefly-db-deploy.yml
@@ -23,8 +23,13 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         envFrom:
+        {{- if not .Values.configs.existingSecret }}
         - configMapRef:
             name: {{ template "firefly-db.fullname" . }}-config
+        {{- else }}
+        - secretRef:
+            name: {{ .Values.configs.existingSecret }}
+        {{- end }}
         resources:
           requests:
             memory: "128Mi"
@@ -39,4 +44,4 @@ spec:
       volumes:
         - name: db-storage
           persistentVolumeClaim:
-            claimName: {{ template "firefly-db.fullname" . }}-storage-claim
+            claimName: {{ default (printf "%s-%s" (template "firefly-db.fullname" .) "storage-claim") .Values.storage.existingClaim }}

--- a/charts/firefly-db/templates/firefly-db-deploy.yml
+++ b/charts/firefly-db/templates/firefly-db-deploy.yml
@@ -44,4 +44,4 @@ spec:
       volumes:
         - name: db-storage
           persistentVolumeClaim:
-            claimName: {{ default (printf "%s-%s" (template "firefly-db.fullname" .) "storage-claim") .Values.storage.existingClaim }}
+            claimName: {{ default (printf "%s-%s" (include "firefly-db.fullname" .) "storage-claim") .Values.storage.existingClaim }}

--- a/charts/firefly-db/templates/firefly-db-pvc.yml
+++ b/charts/firefly-db/templates/firefly-db-pvc.yml
@@ -1,8 +1,9 @@
+{- if eq .Values.storage.existingClaim "" }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ template "firefly-db.fullname" . }}-storage-claim
+  name: {{ printf "%s-%s" (template "firefly-db.fullname" .) "storage-claim" }}
   labels:
     app: {{ template "firefly-db.name" . }}
     chart: {{ template "firefly-db.chart" . }}
@@ -17,3 +18,4 @@ spec:
   resources:
     requests:
       storage: {{ .Values.storage.dataSize }}
+{{- end }}

--- a/charts/firefly-db/templates/firefly-db-pvc.yml
+++ b/charts/firefly-db/templates/firefly-db-pvc.yml
@@ -1,9 +1,9 @@
-{- if eq .Values.storage.existingClaim "" }}
+{{- if eq .Values.storage.existingClaim "" }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ printf "%s-%s" (template "firefly-db.fullname" .) "storage-claim" }}
+  name: {{ printf "%s-%s" (include "firefly-db.fullname" .) "storage-claim" }}
   labels:
     app: {{ template "firefly-db.name" . }}
     chart: {{ template "firefly-db.chart" . }}

--- a/charts/firefly-db/values.yaml
+++ b/charts/firefly-db/values.yaml
@@ -7,6 +7,8 @@ storage:
   class: ~
   accessModes: ReadWriteOnce
   dataSize: 1Gi
+  # -- Use an existing PersistentVolumeClaim, overrides values above
+  existingClaim: ""
 
 configs:
   RESTORE_URL: ""
@@ -20,5 +22,7 @@ configs:
   POSTGRES_HOST_AUTH_METHOD: trust
   POSTGRES_USER: firefly
   POSTGRES_PASSWORD: ""
+    # -- Set this to the name of a secret to load environment variables from. If defined, values in the secret will override values in configs
+  existingSecret: ""
 
 backupSchedule: "0 3 * * *"

--- a/charts/firefly-iii/Chart.yaml
+++ b/charts/firefly-iii/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: firefly-iii
-version: 1.0.3
+version: 1.1.0
 description: Installs Firefly III
 type: application
 home: https://www.firefly-iii.org/

--- a/charts/firefly-iii/README.md
+++ b/charts/firefly-iii/README.md
@@ -1,6 +1,6 @@
 # firefly-iii
 
-![Version: 1.0.3](https://img.shields.io/badge/Version-1.0.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Installs Firefly III
 **Homepage:** <https://www.firefly-iii.org/>
@@ -107,6 +107,7 @@ ingress:
 | persistence.accessModes | string | `"ReadWriteOnce"` |  |
 | persistence.class | string | `""` |  |
 | persistence.enabled | bool | `true` | If you set this to false, uploaded attachments are not stored persistently and will be lost with every restart of the pod |
+| persistence.existingClaim | string | `""` | If you want to use an existing claim, set it here |
 | persistence.storage | string | `"1Gi"` |  |
 | podAnnotations | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |

--- a/charts/firefly-iii/templates/deployment.yaml
+++ b/charts/firefly-iii/templates/deployment.yaml
@@ -72,7 +72,7 @@ spec:
       volumes:
         - name: upload
           persistentVolumeClaim:
-            claimName: {{ default (template "firefly-iii.fullname" .)  .Values.persistence.existingClaim }}
+            claimName: {{ default (include "firefly-iii.fullname" .)  .Values.persistence.existingClaim }}
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/firefly-iii/templates/deployment.yaml
+++ b/charts/firefly-iii/templates/deployment.yaml
@@ -72,7 +72,7 @@ spec:
       volumes:
         - name: upload
           persistentVolumeClaim:
-            claimName: {{ template "firefly-iii.fullname" . }}
+            claimName: {{ default (template "firefly-iii.fullname" .)  .Values.persistence.existingClaim }}
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/firefly-iii/templates/pvc.yaml
+++ b/charts/firefly-iii/templates/pvc.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.persistence.enabled }}
+{{- if and .Values.persistence.enabled (ne .Values.persistence.existingClaim "") }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/charts/firefly-iii/values.yaml
+++ b/charts/firefly-iii/values.yaml
@@ -15,6 +15,8 @@ persistence:
   class: ""
   accessModes: ReadWriteOnce
   storage: 1Gi
+  # -- If you want to use an existing claim, set it here
+  existingClaim: ""
 
 # -- Environment variables for Firefly III. See docs at: https://github.com/firefly-iii/firefly-iii/blob/main/.env.example
 config:


### PR DESCRIPTION
Changes in this pull request:

- One can specify existingClaims for the database and the main chart
- One can now specify an existing secret for the database and the main chart

@JC5 @morremeyer
