### PR TITLE
Fix deployment health checks.

### DIFF
--- a/charts/firefly-iii/templates/deployment.yaml
+++ b/charts/firefly-iii/templates/deployment.yaml
@@ -58,12 +58,19 @@ spec:
             protocol: TCP
         livenessProbe:
           httpGet:
-            path: /
+            path: /health
             port: http
         readinessProbe:
           httpGet:
-            path: /
+            path: /health
             port: http
+        startupProbe:
+          httpGet:
+            path: /health
+            port: http
+          # Give the app 30 x 10 = 300s to startup
+          failureThreshold: 30
+          periodSeconds: 10
         {{- with .Values.resources }}
         resources:
           {{- toYaml . | nindent 12 }}


### PR DESCRIPTION
Fixes issue # (if relevant)

Changes in this pull request:

- Fix k8s deployment health check
- Add startup probe to give the app 5m to start up, this ensures that the container does not go in a crash loop due to not having sufficient time to start up.


@JC5
