### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# @JC5 is code owner for everything
+* @JC5
+
+# morremeyer is maintainer for the helm charts
+charts/ @morremeyer


### PR DESCRIPTION
Proposing this as an automated way to assign both @JC5 and @morremeyer as reviewers to relevant pull requests.

This would make the Pull Request template superfluous and be better integrated with GitHub.

It however requires that I am added to the repository as collaborator with at least **Read** or **Triage** rights.

What do you think @JC5?

References:

* https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
* https://docs.github.com/en/organizations/managing-access-to-your-organizations-repositories/repository-roles-for-an-organization
