### PR TITLE
fix: existing claim should be empty for pvc creation

### DIFF
--- a/charts/firefly-iii/Chart.yaml
+++ b/charts/firefly-iii/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: firefly-iii
-version: 1.2.0
+version: 1.2.1
 description: Installs Firefly III
 type: application
 home: https://www.firefly-iii.org/

--- a/charts/firefly-iii/templates/pvc.yaml
+++ b/charts/firefly-iii/templates/pvc.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.persistence.enabled (ne .Values.persistence.existingClaim "") }}
+{{- if and .Values.persistence.enabled (eq .Values.persistence.existingClaim "") }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:


### PR DESCRIPTION
# Changes in this pull request

To create the pvc, the existing claim name is supposed to be equal to empty. Right now, it's expected that it's not equal to empty for the pvc to be generated.
