### PR TITLE
fix: CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 * @JC5
 
 # morremeyer is maintainer for the helm charts
-charts/ @morremeyer
+/charts/** @morremeyer


### PR DESCRIPTION
This adds all subdirectories. Example taken from https://github.com/dotnet/samples/blob/36b6f4c43c88cd0d46be38e272f8aa13bce5c9db/.github/CODEOWNERS#L18

Changes in this pull request:

- fixes the Code Owners so that @morremeyer is automatically requested as reviewer on `charts/**`
