### PR TITLE
Wrong volume path for uploaded files

### DIFF
--- a/kustomize/firefly-iii.yaml
+++ b/kustomize/firefly-iii.yaml
@@ -81,7 +81,7 @@ spec:
         - containerPort: 8080
           name: firefly-iii
         volumeMounts:
-        - mountPath: "/var/www/html/firefly-iii/storage/upload"
+        - mountPath: "/var/www/html/storage/upload"
           name: firefly-iii-upload 
         imagePullPolicy: Always
       volumes:


### PR DESCRIPTION
Upon debugging why I lost an attachment after a deployment restart, I came upon a possibly wrong path for the upload volume mount.
Changing it from /var/www/html/storage/upload solved the problem for me and the data now survives a deployment restart.

Changes in this pull request:
- mountPath to /var/www/html/storage/upload in firefly-iii.yaml
