### PR TITLE
feat: add env vars configurable for importer

### DIFF
--- a/charts/importer/Chart.yaml
+++ b/charts/importer/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: importer
-version: 1.1.3
+version: 1.2.0
 description: Deploys the importer chart for Firefly III
 type: application
 home: https://www.firefly-iii.org/

--- a/charts/importer/templates/configmap.yaml
+++ b/charts/importer/templates/configmap.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.config.env }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "importer.fullname" . }}
+  labels:
+    {{- include "importer.labels" . | nindent 4 }}
+data:
+{{- range $key, $value := .Values.config.env }}
+  {{ $key }}: {{ $value | quote }}
+{{- end }}
+{{- end }}

--- a/charts/importer/templates/deployment.yaml
+++ b/charts/importer/templates/deployment.yaml
@@ -49,6 +49,23 @@ spec:
             {{- end }}
             - name: TRUSTED_PROXIES
               value: {{ .Values.trustedProxies | quote }}
+          {{- if or .Values.config.envValueFrom }}
+          {{- range $key, $value := .Values.config.envValueFrom }}
+            - name: {{ $key }}
+              valueFrom: {{- $value | toYaml | nindent 16 }}
+          {{- end }}
+          {{- end }}
+          {{- if or (.Values.config.env) (.Values.config.existingSecret) }}
+          envFrom:
+            {{- if .Values.config.env }}
+            - configMapRef:
+                name: {{ template "importer.fullname" . }}
+            {{- end }}
+            {{- if .Values.config.existingSecret }}
+            - secretRef:
+                name: {{ .Values.config.existingSecret }}
+            {{- end }}
+          {{- end }}
           ports:
             - name: http
               containerPort: 8080

--- a/charts/importer/values.yaml
+++ b/charts/importer/values.yaml
@@ -17,6 +17,19 @@ fireflyiii:
     # -- The access token in plain text
     accessToken: ""
 
+# -- Environment variables for the importer. See docs at: https://github.com/firefly-iii/data-importer/blob/main/.env.example
+config:
+  # -- Set this to the name of a secret to load environment variables from. If defined, values in the secret will override values in config.env
+  existingSecret: ""
+
+  # -- Set environment variables from configMaps or Secrets
+  envValueFrom: {}
+
+  # -- Directly defined environment variables. Use this for non-secret configuration values.
+  env:
+    IGNORE_DUPLICATE_ERRORS: "false"
+    TZ: "Europe/Amsterdam"
+
 image:
   repository: fireflyiii/data-importer
   pullPolicy: IfNotPresent


### PR DESCRIPTION
Changes in this pull request:
- add the ability to configure env variables for the importer (For nordigen, spectre, ...)