### PR TITLE
feat: fix and impove some values.yaml options

### DIFF
--- a/charts/firefly-iii/Chart.yaml
+++ b/charts/firefly-iii/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: firefly-iii
-version: 1.3.2
+version: 1.3.3
 description: Installs Firefly III
 type: application
 home: https://www.firefly-iii.org/

--- a/charts/firefly-iii/templates/cronjob.yaml
+++ b/charts/firefly-iii/templates/cronjob.yaml
@@ -61,7 +61,7 @@ spec:
                   valueFrom:
                     secretKeyRef:
                       name: {{ .Values.cronjob.auth.existingSecret }}
-                      key: token
+                      key: {{ .Values.cronjob.auth.secretKey }}
                 {{- end }}
               command:
                 - /usr/bin/curl

--- a/charts/firefly-iii/values.yaml
+++ b/charts/firefly-iii/values.yaml
@@ -12,7 +12,7 @@ fullnameOverride: ""
 persistence:
   # -- If you set this to false, uploaded attachments are not stored persistently and will be lost with every restart of the pod
   enabled: true
-  class: ""
+  storageClassName: ""
   accessModes: ReadWriteOnce
   storage: 1Gi
   # -- If you want to use an existing claim, set it here

--- a/charts/firefly-iii/values.yaml
+++ b/charts/firefly-iii/values.yaml
@@ -47,6 +47,9 @@ cronjob:
     # -- The name of a secret containing a data.token field with the cronjob token
     existingSecret: ""
 
+    # -- The name of the key in the existing secret to get the cronjob token from
+    secretKey: "token"
+
     # -- The token in plain text
     token: ""
 


### PR DESCRIPTION
Changes in this pull request:

- Adds `secretKey` to the cronjob auth section with a default value of `token`
- Changes the class key to storageClassName under the persistence section.
- Bumps the firefly-iii chart version to 1.3.3
