### PR TITLE
chore: bump chart versions for firefly-iii-stack

### DIFF
--- a/charts/firefly-iii-stack/Chart.yaml
+++ b/charts/firefly-iii-stack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: firefly-iii-stack
-version: 0.6.1
+version: 0.7.0
 description: Installs Firefly III stack (db, app, importer)
 type: application
 dependencies:
@@ -9,11 +9,11 @@ dependencies:
   condition: firefly-db.enabled
   repository: https://firefly-iii.github.io/kubernetes/
 - name: firefly-iii
-  version: 1.3.2
+  version: 1.3.3
   condition: firefly-iii.enabled
   repository: https://firefly-iii.github.io/kubernetes/
 - name: importer
-  version: 1.2.0
+  version: 1.3.0
   condition: importer.enabled
   repository: https://firefly-iii.github.io/kubernetes/
 home: https://github.com/firefly-iii/kubernetes

--- a/charts/firefly-iii-stack/README.md
+++ b/charts/firefly-iii-stack/README.md
@@ -1,6 +1,6 @@
 # firefly-iii-stack
 
-![Version: 0.6.1](https://img.shields.io/badge/Version-0.6.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Installs Firefly III stack (db, app, importer)
 **Homepage:** <https://github.com/firefly-iii/kubernetes>
@@ -17,8 +17,8 @@ Installs Firefly III stack (db, app, importer)
 | Repository | Name | Version |
 |------------|------|---------|
 | https://firefly-iii.github.io/kubernetes/ | firefly-db | 0.1.0 |
-| https://firefly-iii.github.io/kubernetes/ | firefly-iii | 1.3.2 |
-| https://firefly-iii.github.io/kubernetes/ | importer | 1.2.0 |
+| https://firefly-iii.github.io/kubernetes/ | firefly-iii | 1.3.3 |
+| https://firefly-iii.github.io/kubernetes/ | importer | 1.3.0 |
 
 ## Upgrading
 


### PR DESCRIPTION
Changes in this pull request: Updates the firefly-iii and importer charts to current versions.