### PR TITLE
fix: Change storage path of postgres to prevent data loss on pod restart

### DIFF
--- a/charts/firefly-db/templates/firefly-db-deploy.yml
+++ b/charts/firefly-db/templates/firefly-db-deploy.yml
@@ -22,6 +22,9 @@ spec:
       - name: {{ template "firefly-db.fullname" . }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        env:
+        - name: PGDATA
+          value: /firefly-iii/data
         envFrom:
         {{- if not .Values.configs.existingSecret }}
         - configMapRef:
@@ -39,7 +42,7 @@ spec:
             cpu: "500m"
         volumeMounts:
           - name: db-storage
-            mountPath: /var/lib/postgresql
+            mountPath: /firefly-iii
             subPath: data
       volumes:
         - name: db-storage

--- a/charts/firefly-db/templates/firefly-db-restore-job.yml
+++ b/charts/firefly-db/templates/firefly-db-restore-job.yml
@@ -9,7 +9,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
   annotations:
-    "helm.sh/hook": post-install
+    "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "-5"
     "helm.sh/hook-delete-policy": hook-succeeded
 spec:


### PR DESCRIPTION
Change storage path of postgres to prevent data loss on pod restart

Fixes issue #6435

Changes in this pull request:

- Set database storage path to `/firefly-iii/data` and update volume mount accordingly
- Run data restore hook after `helm upgrade`
