### PR TITLE
Add a pvc based backup target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 # Helm chart lock files - those would need manual updates.
 # As we have all charts in the same repository, we can assume trust between them
 Chart.lock
+
+.idea

--- a/charts/firefly-db/Chart.yaml
+++ b/charts/firefly-db/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: firefly-db
-version: 0.1.0
+version: 0.2.0
 description: Installs a postgres db for Firefly III
 type: application
 sources:

--- a/charts/firefly-db/Chart.yaml
+++ b/charts/firefly-db/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: firefly-db
-version: 0.2.0
+version: 0.2.1
 description: Installs a postgres db for Firefly III
 type: application
 sources:

--- a/charts/firefly-db/templates/backup.tpl
+++ b/charts/firefly-db/templates/backup.tpl
@@ -1,0 +1,38 @@
+{{ define "backupJobSpec" }}
+spec:
+  containers:
+  - name: {{ template "firefly-db.fullname" . }}-backup-job
+    image: alpine:3.13
+    imagePullPolicy: IfNotPresent
+    envFrom:
+    - configMapRef:
+        name: {{ template "firefly-db.fullname" . }}-config
+    command:
+    - /bin/sh
+    - -c
+    - |
+      set -e
+      apk update
+      apk add curl
+      apk add postgresql
+      echo "creating backup file"
+      pg_dump -h $DBHOST -p $DBPORT -U $DBUSER --format=p --clean -d $DBNAME > /var/lib/backup/$DBNAME.sql
+      ls -la
+      {{- if eq .Values.backup.destination "http" }}
+      echo "uploading backup file"
+      curl -F "filename=@/var/lib/backup/${DBNAME}.sql" $BACKUP_URL
+      {{- end }}
+      echo "done"
+    volumeMounts:
+      - name: backup-storage
+        mountPath: /var/lib/backup
+  restartPolicy: Never
+  volumes:
+    - name: backup-storage
+      {{- if eq .Values.backup.destination "pvc" }}
+      persistentVolumeClaim:
+        claimName: {{ default (printf "%s-%s" (include "firefly-db.fullname" .) "backup-storage-claim") .Values.backup.pvc.existingClaim }}
+      {{- else }}
+      emptyDir: {}
+      {{- end }}
+{{ end }}

--- a/charts/firefly-db/templates/firefly-backup-pvc.yml
+++ b/charts/firefly-db/templates/firefly-backup-pvc.yml
@@ -1,0 +1,21 @@
+{{- if and (eq .Values.backup.destination "pvc") (eq .Values.backup.pvc.existingClaim "") }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: {{ printf "%s-%s" (include "firefly-db.fullname" .) "backup-storage-claim" }}
+  labels:
+    app: {{ template "firefly-db.name" . }}
+    chart: {{ template "firefly-db.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  {{- with .Values.backup.pvc.class }}
+  storageClassName: {{ . }}
+  {{- end }}
+  accessModes:
+    - {{ .Values.backup.pvc.accessModes }}
+  resources:
+    requests:
+      storage: {{ .Values.backup.pvc.dataSize }}
+{{- end }}

--- a/charts/firefly-db/templates/firefly-db-backup-job.yml
+++ b/charts/firefly-db/templates/firefly-db-backup-job.yml
@@ -17,26 +17,4 @@ spec:
   parallelism: 1
   completions: 1
   template:
-    spec:
-      containers:
-      - name: {{ template "firefly-db.fullname" . }}-backup-job
-        image: alpine:3.13
-        imagePullPolicy: IfNotPresent
-        envFrom:
-        - configMapRef:
-            name: {{ template "firefly-db.fullname" . }}-config
-        command:
-        - /bin/sh
-        - -c
-        - |
-          set -e
-          apk update
-          apk add curl
-          apk add postgresql
-          echo "creating backup file"
-          pg_dump -h $DBHOST -p $DBPORT -U $DBUSER --format=p --clean -d $DBNAME > $DBNAME.sql
-          ls -la
-          echo "uploading backup file"
-          curl -F "filename=@$(DBNAME).sql" $BACKUP_URL
-          echo "done"
-      restartPolicy: Never
+    {{- include "backupJobSpec" . | indent 4 }}

--- a/charts/firefly-db/templates/firefly-db-cron-backup.yml
+++ b/charts/firefly-db/templates/firefly-db-cron-backup.yml
@@ -16,27 +16,5 @@ spec:
   jobTemplate:
     spec:
       template:
-        spec:
-          containers:
-            - name: {{ template "firefly-db.fullname" . }}-backup
-              image: alpine:3.13
-              imagePullPolicy: IfNotPresent
-              envFrom:
-              - configMapRef:
-                  name: {{ template "firefly-db.fullname" . }}-config
-              command:
-              - /bin/sh
-              - -c
-              - |
-                set -e
-                apk update
-                apk add curl
-                apk add postgresql
-                echo "creating backup file"
-                pg_dump -h $DBHOST -p $DBPORT -U $DBUSER --format=p --clean -d $DBNAME > $DBNAME.sql
-                ls -la
-                echo "uploading backup file"
-                curl -F "filename=@$(DBNAME).sql" $BACKUP_URL
-                echo "done"
-          restartPolicy: Never
+        {{- include "backupJobSpec" . | indent 8 }}
 {{ end }}

--- a/charts/firefly-db/templates/firefly-db-deploy.yml
+++ b/charts/firefly-db/templates/firefly-db-deploy.yml
@@ -39,7 +39,7 @@ spec:
             cpu: "500m"
         volumeMounts:
           - name: db-storage
-            mountPath: /var/lib/postgresql
+            mountPath: /var/lib/postgresql/data
             subPath: data
       volumes:
         - name: db-storage

--- a/charts/firefly-db/templates/firefly-db-restore-job.yml
+++ b/charts/firefly-db/templates/firefly-db-restore-job.yml
@@ -32,10 +32,23 @@ spec:
           apk update
           apk add curl
           apk add postgresql
+          {{- if eq .Values.backup.destination "http" }}
           echo "Downloading latest backup"
-          curl $RESTORE_URL --output $DBNAME.sql
+          curl $RESTORE_URL --output /var/lib/backup/${DBNAME}.sql
+          {{- end }}
           echo "Performing restore of db"
           ls -la
-          psql -h $DBHOST -p $DBPORT -U $DBUSER < $DBNAME.sql
+          psql -h $DBHOST -p $DBPORT -U $DBUSER < /var/lib/backup/${DBNAME}.sql
           echo "done"
+        volumeMounts:
+          - name: backup-storage
+            mountPath: /var/lib/backup
       restartPolicy: Never
+      volumes:
+        - name: backup-storage
+          {{- if eq .Values.backup.destination "pvc" }}
+          persistentVolumeClaim:
+            claimName: {{ default (printf "%s-%s" (include "firefly-db.fullname" .) "backup-storage-claim") .Values.backup.pvc.existingClaim }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}

--- a/charts/firefly-db/values.yaml
+++ b/charts/firefly-db/values.yaml
@@ -9,6 +9,16 @@ storage:
   dataSize: 1Gi
   # -- Use an existing PersistentVolumeClaim, overrides values above
   existingClaim: ""
+  
+backup:
+  # There are two possible backup destinations currently implemented, http and pvc
+  destination: http
+  pvc:
+    class: ~
+    accessModes: ReadWriteOnce
+    dataSize: 1Gi
+    # -- Use an existing PersistentVolumeClaim, overrides values above
+    existingClaim: ""
 
 configs:
   RESTORE_URL: ""


### PR DESCRIPTION
The current backup target with the HTTP endpoint is not very well documented, and there is no standard tooling for this. This PR adds an additional backup target implemented by a second PVC. This is self-contained and should make it easy to rollout the firefly-iii stack chart without any additional infrastructure

Fixes issue # (if relevant)

Changes in this pull request:

- Add PVC backup target for postgresql
- Refactor backup job code for increased code reuse
