### PR TITLE
feat: add support for creating Secret to store sensitive env variables

### DIFF
--- a/charts/firefly-iii/Chart.yaml
+++ b/charts/firefly-iii/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: firefly-iii
-version: 1.3.3
+version: 1.4.0
 description: Installs Firefly III
 type: application
 home: https://www.firefly-iii.org/

--- a/charts/firefly-iii/README.md
+++ b/charts/firefly-iii/README.md
@@ -127,6 +127,7 @@ ingress:
 | podSecurityContext | object | `{}` |  |
 | replicaCount | int | `1` |  |
 | resources | object | `{}` |  |
+| secrets | object | `{"env":{"APP_PASSWORD":"CHANGE_ENCRYPT_ME","DB_PASSWORD":"CHANGE_ENCRYPT_ME"}}` | Create a new Secret from values file to store sensitive environment variables. Make sure to keep your secrets encrypted in the repository! For example, you can use the 'helm secrets' plugin (https://github.com/jkroepke/helm-secrets) to encrypt and manage secrets. If the 'config.existingSecret' value is set, a new Secret will not be created. |
 | securityContext | object | `{}` |  |
 | service.port | int | `80` |  |
 | service.type | string | `"ClusterIP"` |  |

--- a/charts/firefly-iii/README.md
+++ b/charts/firefly-iii/README.md
@@ -1,6 +1,6 @@
 # firefly-iii
 
-![Version: 1.3.3](https://img.shields.io/badge/Version-1.3.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 1.4.0](https://img.shields.io/badge/Version-1.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Installs Firefly III
 **Homepage:** <https://www.firefly-iii.org/>

--- a/charts/firefly-iii/templates/deployment.yaml
+++ b/charts/firefly-iii/templates/deployment.yaml
@@ -52,6 +52,9 @@ spec:
           {{- if .Values.config.existingSecret }}
           - secretRef:
               name: {{ .Values.config.existingSecret }}
+          {{- else if .Values.secrets.env }}
+          - secretRef:
+              name: {{ template  "firefly-iii.fullname" . }}
           {{- end }}
         {{- end }}
         {{- if .Values.persistence.enabled }}

--- a/charts/firefly-iii/templates/secret.yaml
+++ b/charts/firefly-iii/templates/secret.yaml
@@ -1,0 +1,12 @@
+{{ if and (.Values.secrets.env) (not .Values.config.existingSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "firefly-iii.fullname" . }}
+  labels:
+    {{- include "firefly-iii.labels" . | nindent 4 }}
+data:
+{{- range $key, $value := .Values.secrets.env }}
+  {{ $key }}: {{ $value | b64enc | quote }}
+{{- end }}
+{{- end }}

--- a/charts/firefly-iii/values.yaml
+++ b/charts/firefly-iii/values.yaml
@@ -37,6 +37,12 @@ config:
     TZ: "Europe/Amsterdam"
     TRUSTED_PROXIES: "**"
 
+# -- Create a new Secret from values file to store sensitive environment variables. Make sure to keep your secrets encrypted in the repository! For example, you can use the 'helm secrets' plugin (https://github.com/jkroepke/helm-secrets) to encrypt and manage secrets. If the 'config.existingSecret' value is set, a new Secret will not be created.
+secrets:
+  env:
+    APP_PASSWORD: "CHANGE_ENCRYPT_ME"
+    DB_PASSWORD: "CHANGE_ENCRYPT_ME"
+
 # -- A cronjob for [recurring Firefly III tasks](https://docs.firefly-iii.org/firefly-iii/advanced-installation/cron/).
 cronjob:
   # -- Set to true to enable the CronJob. Note that you need to specify either cronjob.auth.existingSecret or cronjob.auth.token for it to actually be deployed.


### PR DESCRIPTION
User can use helm secrets plugin to pass encrypted values file.

Fixes issue # (if relevant)

Changes in this pull request:

- new `secrets` section in `values.yaml` - sensitive env variables can be stored in Secret rather than in ConfigMap
- optional, only created when `config.existingSecret` is not used, making it backwards compatible.
