### PR TITLE
update cron resource to use new api

### DIFF
--- a/kustomize/ingress-firefly-iii-cron.yaml
+++ b/kustomize/ingress-firefly-iii-cron.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: "firefly-iii-cron"


### PR DESCRIPTION
To apply the kustomize workflow to my kube cluster I had to update the cron api version
Thanks for the cool software 

update to final release of cron api
https://kubernetes.io/docs/reference/using-api/deprecation-guide/#cronjob-v125

Fixes issue # (if relevant)

Changes in this pull request:
update api reference to final from beta1
- 
- 
- 
