### PR TITLE
add extraVolumes, extraVolumeMounts to helm chart

### DIFF
--- a/charts/firefly-iii/Chart.yaml
+++ b/charts/firefly-iii/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: firefly-iii
-version: 1.4.0
+version: 1.5.0
 description: Installs Firefly III
 type: application
 home: https://www.firefly-iii.org/

--- a/charts/firefly-iii/README.md
+++ b/charts/firefly-iii/README.md
@@ -132,3 +132,5 @@ ingress:
 | service.port | int | `80` |  |
 | service.type | string | `"ClusterIP"` |  |
 | tolerations | list | `[]` |  |
+| extraVolumes | list | `[]` |  |
+| extraVolumeMounts | list | `[]` |  |

--- a/charts/firefly-iii/README.md
+++ b/charts/firefly-iii/README.md
@@ -1,6 +1,6 @@
 # firefly-iii
 
-![Version: 1.4.0](https://img.shields.io/badge/Version-1.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 1.5.0](https://img.shields.io/badge/Version-1.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Installs Firefly III
 **Homepage:** <https://www.firefly-iii.org/>

--- a/charts/firefly-iii/templates/deployment.yaml
+++ b/charts/firefly-iii/templates/deployment.yaml
@@ -57,10 +57,15 @@ spec:
               name: {{ template  "firefly-iii.fullname" . }}
           {{- end }}
         {{- end }}
-        {{- if .Values.persistence.enabled }}
+        {{- if or (.Values.persistence.enabled) (.Values.extraVolumeMounts) }}
         volumeMounts:
+          {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 10 }}
+          {{- end }}
+          {{- if .Values.persistence.enabled }}
           - name: upload
             mountPath: "/var/www/html/storage/upload"
+          {{- end }}
         {{- end }}
         ports:
           - name: http
@@ -85,11 +90,16 @@ spec:
         resources:
           {{- toYaml . | nindent 12 }}
         {{- end }}
-      {{- if .Values.persistence.enabled }}
+      {{- if or (.Values.persistence.enabled) (.Values.extraVolumes) }}
       volumes:
+        {{- with .Values.extraVolumes }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- if (.Values.persistence.enabled) }}
         - name: upload
           persistentVolumeClaim:
             claimName: {{ default (include "firefly-iii.fullname" .)  .Values.persistence.existingClaim }}
+        {{- end }}
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/firefly-iii/values.yaml
+++ b/charts/firefly-iii/values.yaml
@@ -162,4 +162,3 @@ extraVolumeMounts: []
   # - name: db-tls-firefly
   #   mountPath: /db-cert
   #   readOnly: true
-

--- a/charts/firefly-iii/values.yaml
+++ b/charts/firefly-iii/values.yaml
@@ -149,3 +149,17 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# Here, you can specify custom volumes to use.
+extraVolumes: []
+  # - name: db-tls-firefly
+  #   secret:
+  #     secretName: db-tls-firefly
+  #     defaultMode: 0440
+
+# And here, your custom volume mounts.
+extraVolumeMounts: []
+  # - name: db-tls-firefly
+  #   mountPath: /db-cert
+  #   readOnly: true
+


### PR DESCRIPTION
Fixes issue [#8075](https://github.com/firefly-iii/firefly-iii/issues/8075)
Changes in this pull request:

- Bumped version of `firefly-iii` helm chart to 1.5
- Added `extraVolumes` and `extraVolumeMounts` to `values.yaml`
- Added some documentation about how to use these options