### PR TITLE
add DB_HOST and APP_KEY env variables

### DIFF
--- a/charts/firefly-iii/Chart.yaml
+++ b/charts/firefly-iii/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: firefly-iii
-version: 1.6
+version: 1.6.0
 description: Installs Firefly III
 type: application
 home: https://www.firefly-iii.org/

--- a/charts/firefly-iii/Chart.yaml
+++ b/charts/firefly-iii/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: firefly-iii
-version: 1.5.0
+version: 1.6
 description: Installs Firefly III
 type: application
 home: https://www.firefly-iii.org/

--- a/charts/firefly-iii/values.yaml
+++ b/charts/firefly-iii/values.yaml
@@ -29,7 +29,7 @@ config:
   # -- Directly defined environment variables. Use this for non-secret configuration values.
   env:
     DB_CONNECTION: pgsql
-  #  DB_HOST: #If using external database host
+  #  DB_HOST:
     DB_PORT: "5432"
     DB_DATABASE: firefly
     DB_USERNAME: firefly
@@ -43,8 +43,8 @@ secrets:
   env:
     APP_PASSWORD: "CHANGE_ENCRYPT_ME"
     DB_PASSWORD: "CHANGE_ENCRYPT_ME"
-    APP_KEY: "INSERT_SECURE_STRING_HERE" # APP_KEY is required by Laravel but not will not be properly configured during Helm installation process
-
+    APP_KEY: "INSERT_SECURE_STRING_HERE"
+    
 # -- A cronjob for [recurring Firefly III tasks](https://docs.firefly-iii.org/firefly-iii/advanced-installation/cron/).
 cronjob:
   # -- Set to true to enable the CronJob. Note that you need to specify either cronjob.auth.existingSecret or cronjob.auth.token for it to actually be deployed.

--- a/charts/firefly-iii/values.yaml
+++ b/charts/firefly-iii/values.yaml
@@ -29,6 +29,7 @@ config:
   # -- Directly defined environment variables. Use this for non-secret configuration values.
   env:
     DB_CONNECTION: pgsql
+  #  DB_HOST: #If using external database host
     DB_PORT: "5432"
     DB_DATABASE: firefly
     DB_USERNAME: firefly
@@ -42,6 +43,7 @@ secrets:
   env:
     APP_PASSWORD: "CHANGE_ENCRYPT_ME"
     DB_PASSWORD: "CHANGE_ENCRYPT_ME"
+    APP_KEY: "INSERT_SECURE_STRING_HERE" # APP_KEY is required by Laravel but not will not be properly configured during Helm installation process
 
 # -- A cronjob for [recurring Firefly III tasks](https://docs.firefly-iii.org/firefly-iii/advanced-installation/cron/).
 cronjob:


### PR DESCRIPTION
Fixes issue # (if relevant)

Changes in this pull request:

- add DB_HOST for use with external database host
- add APP_KEY to secure env variables. This is required by Laravel/PHP but is not properly configured during the installation process using Helm
