### PR TITLE
feat: Allow probes to be configured

### DIFF
--- a/charts/firefly-iii/templates/deployment.yaml
+++ b/charts/firefly-iii/templates/deployment.yaml
@@ -71,21 +71,33 @@ spec:
           - name: http
             containerPort: 8080
             protocol: TCP
+        {{- if .Values.livenessProbe.enabled }}
         livenessProbe:
+          {{- with .Values.livenessProbe }}
+            {{- omit . "enabled" | toYaml | nindent 10 }}
+          {{- end }}
           httpGet:
             path: /health
             port: http
+        {{- end }}
+        {{- if .Values.readinessProbe.enabled }}
         readinessProbe:
+          {{- with .Values.readinessProbe }}
+            {{- omit . "enabled" | toYaml | nindent 10 }}
+          {{- end }}
           httpGet:
             path: /health
             port: http
+        {{- end }}
+        {{- if .Values.startupProbe.enabled }}
         startupProbe:
+          {{- with .Values.startupProbe }}
+            {{- omit . "enabled" | toYaml | nindent 10 }}
+          {{- end }}
           httpGet:
             path: /health
             port: http
-          # Give the app 30 x 10 = 300s to startup
-          failureThreshold: 30
-          periodSeconds: 10
+        {{- end }}
         {{- with .Values.resources }}
         resources:
           {{- toYaml . | nindent 12 }}

--- a/charts/firefly-iii/values.yaml
+++ b/charts/firefly-iii/values.yaml
@@ -162,3 +162,27 @@ extraVolumeMounts: []
   # - name: db-tls-firefly
   #   mountPath: /db-cert
   #   readOnly: true
+
+readinessProbe:
+  enabled: true
+  initialDelaySeconds: 0
+  periodSeconds: 10
+  successThreshold: 1
+  timeoutSeconds: 1
+  failureThreshold: 3
+
+startupProbe:
+  enabled: true
+  initialDelaySeconds: 0
+  periodSeconds: 10
+  successThreshold: 1
+  timeoutSeconds: 1
+  failureThreshold: 30
+
+livenessProbe:
+  enabled: true
+  initialDelaySeconds: 0
+  periodSeconds: 10
+  successThreshold: 1
+  timeoutSeconds: 1
+  failureThreshold: 3


### PR DESCRIPTION
Currently, probes (readiness, liveness, startup) are hard coded into the template and cannot be changed. This PR makes the necessary changes for those probes to be configurable from the `values.yaml`.
