### PR TITLE
feat: Allow failureThreshhold to be configured

### DIFF
--- a/charts/firefly-iii/templates/deployment.yaml
+++ b/charts/firefly-iii/templates/deployment.yaml
@@ -83,8 +83,8 @@ spec:
           httpGet:
             path: /health
             port: http
-          # Give the app 30 x 10 = 300s to startup
-          failureThreshold: 30
+          # Give the app 45 x 10 = 450s to startup
+          failureThreshold: 45
           periodSeconds: 10
         {{- with .Values.resources }}
         resources:


### PR DESCRIPTION
Following discussion in https://github.com/firefly-iii/kubernetes/pull/59

This PR adds the ability to configure the `failureThreshold` for the `startupProbe`.

Let me know if this is ok with you :slightly_smiling_face: 