### PR TITLE
Fix connection to firefly-db:0.2.1 and updated firefly-iii docker image 5.6.14 -> 6.1.1

### DIFF
--- a/charts/firefly-iii/Chart.yaml
+++ b/charts/firefly-iii/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: firefly-iii
-version: 1.6.0
+version: 1.7.0
 description: Installs Firefly III
 type: application
 home: https://www.firefly-iii.org/

--- a/charts/firefly-iii/templates/_helpers.tpl
+++ b/charts/firefly-iii/templates/_helpers.tpl
@@ -60,3 +60,11 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+
+{{/*
+Create the APP_KEY used for encryption, should be random 32 characters
+*/}}
+{{- define "firefly-iii.app-key" -}}
+{{- randAlphaNum 32 | nospace -}}
+{{- end }}

--- a/charts/firefly-iii/templates/secret.yaml
+++ b/charts/firefly-iii/templates/secret.yaml
@@ -9,4 +9,5 @@ data:
 {{- range $key, $value := .Values.secrets.env }}
   {{ $key }}: {{ $value | b64enc | quote }}
 {{- end }}
+  APP_KEY: {{ include "firefly-iii.app-key" . | b64enc | quote}}
 {{- end }}

--- a/charts/firefly-iii/values.yaml
+++ b/charts/firefly-iii/values.yaml
@@ -29,10 +29,10 @@ config:
   # -- Directly defined environment variables. Use this for non-secret configuration values.
   env:
     DB_HOST: "firefly-db"
-    #DB_CONNECTION: pgsql
-    #DB_PORT: "5432"
-    #DB_DATABASE: firefly
-    #DB_USERNAME: firefly
+    # DB_CONNECTION: pgsql
+    # DB_PORT: "5432"
+    # DB_DATABASE: firefly
+    # DB_USERNAME: firefly
     DEFAULT_LANGUAGE: "en_US"
     DEFAULT_LOCALE: "equal"
     TZ: "Europe/Amsterdam"

--- a/charts/firefly-iii/values.yaml
+++ b/charts/firefly-iii/values.yaml
@@ -29,6 +29,10 @@ config:
   # -- Directly defined environment variables. Use this for non-secret configuration values.
   env:
     DB_HOST: "firefly-db"
+    #DB_CONNECTION: pgsql
+    #DB_PORT: "5432"
+    #DB_DATABASE: firefly
+    #DB_USERNAME: firefly
     DEFAULT_LANGUAGE: "en_US"
     DEFAULT_LOCALE: "equal"
     TZ: "Europe/Amsterdam"

--- a/charts/firefly-iii/values.yaml
+++ b/charts/firefly-iii/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 1
 image:
   repository: "fireflyiii/core"
   pullPolicy: IfNotPresent
-  tag: version-5.6.14
+  tag: version-6.1.1
 
 imagePullSecrets: []
 nameOverride: ""
@@ -28,10 +28,7 @@ config:
 
   # -- Directly defined environment variables. Use this for non-secret configuration values.
   env:
-    DB_CONNECTION: pgsql
-    DB_PORT: "5432"
-    DB_DATABASE: firefly
-    DB_USERNAME: firefly
+    DB_HOST: "firefly-db"
     DEFAULT_LANGUAGE: "en_US"
     DEFAULT_LOCALE: "equal"
     TZ: "Europe/Amsterdam"


### PR DESCRIPTION
Fixes issue: When I tried to install (with helm install) latest of firefly-iii and latest of firefly-db they were not working together automatically.

Changes in this pull request:
- DB_HOST now refers to the service name (firefly-db) and app can communicate with DB
- APP_KEY is created automatically as a random 32 long string as requested by the app
- new changes were tested with new docker image version and are working, so I also updated the image to use the latest available

