### PR TITLE
Fix: Allow APP_KEY to be pre-defined

### DIFF
--- a/charts/firefly-iii/Chart.yaml
+++ b/charts/firefly-iii/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: firefly-iii
-version: 1.7.1
+version: 1.7.2
 description: Installs Firefly III
 type: application
 home: https://www.firefly-iii.org/

--- a/charts/firefly-iii/templates/_helpers.tpl
+++ b/charts/firefly-iii/templates/_helpers.tpl
@@ -68,10 +68,14 @@ In order to NOT create a new key for each upgrade a check to the secret is done,
 if secret exists, use previous values, if not, create a new key
 */}}
 {{- define "firefly-iii.app-key" -}}
-  {{- $secret_key := lookup "v1" "Secret" .Release.Namespace (printf "%s-app-key" ( include "firefly-iii.fullname" . )) -}}
-  {{- if $secret_key -}}
-    {{ $secret_key.data.APP_KEY | b64dec }}
+  {{- if .Values.secrets.appKey -}}
+    {{ .Values.secrets.appKey }}
   {{- else -}}
-    {{- randAlphaNum 32 | nospace -}}
+    {{- $secret_key := lookup "v1" "Secret" .Release.Namespace (printf "%s-app-key" ( include "firefly-iii.fullname" . )) -}}
+    {{- if $secret_key -}}
+      {{ $secret_key.data.APP_KEY | b64dec }}
+    {{- else -}}
+      {{- randAlphaNum 32 | nospace -}}
+    {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/firefly-iii/templates/_helpers.tpl
+++ b/charts/firefly-iii/templates/_helpers.tpl
@@ -69,7 +69,7 @@ if secret exists, use previous values, if not, create a new key
 */}}
 {{- define "firefly-iii.app-key" -}}
   {{- if .Values.secrets.appKey -}}
-    {{ .Values.secrets.appKey }}
+    {{ include "firefly-iii.validate-app-key" . | required "appKey needs to be exactly 32 characters" }}
   {{- else -}}
     {{- $secret_key := lookup "v1" "Secret" .Release.Namespace (printf "%s-app-key" ( include "firefly-iii.fullname" . )) -}}
     {{- if $secret_key -}}
@@ -79,3 +79,13 @@ if secret exists, use previous values, if not, create a new key
     {{- end }}
   {{- end }}
 {{- end }}
+
+{{/*
+Validate if length of APP_KEY is 32 characters
+*/}}
+{{- define "firefly-iii.validate-app-key" -}}
+  {{ $length := len .Values.secrets.appKey }}
+  {{- if eq 32 $length }}
+    {{ .Values.secrets.appKey }}
+  {{- end -}}
+{{- end -}}

--- a/charts/firefly-iii/templates/secret-app-key.yaml
+++ b/charts/firefly-iii/templates/secret-app-key.yaml
@@ -5,4 +5,4 @@ metadata:
   labels:
     {{- include "firefly-iii.labels" . | nindent 4 }}
 data:
-  APP_KEY: {{ include "firefly-iii.app-key" . | b64enc | quote}}
+  APP_KEY: {{ include "firefly-iii.app-key" . | b64enc | quote }}

--- a/charts/firefly-iii/values.yaml
+++ b/charts/firefly-iii/values.yaml
@@ -43,6 +43,9 @@ secrets:
   env:
     APP_PASSWORD: "CHANGE_ENCRYPT_ME"
     DB_PASSWORD: "CHANGE_ENCRYPT_ME"
+  # -- Statically set the APP_KEY in case this is desired over the autogeneration. Should be a random 32-character string.
+  # -- Can be generated using: `openssl rand 32`
+  # appKey: "CHANGE_ME"
 
 # -- A cronjob for [recurring Firefly III tasks](https://docs.firefly-iii.org/firefly-iii/advanced-installation/cron/).
 cronjob:


### PR DESCRIPTION
When using certain GitOps systems, the app-key secret is regenerated with every check. This PR allows a user to pre-define the value for `APP_KEY` in the chart values.

Use case: ArgoCD uses `helm template` to generate manifests and compares these to the deployed resources. As this command does not directly contacts the kubernetes API, the lookup value for the app-key secret (as defined in the `_helpers.tpl`) results in the value for `APP_KEY` to change on every sync/refresh.

Proposed changes in this pull request:
- Changes to `values.yaml`:
  - Adds a new key under `secrets.appKey` that allows you to define the value for `APP_KEY`. This is commented by default
  - Adds help on how to generate the `APP_KEY` value
- Changes to `_helpers.tpl`:
  - Changes the check for the presence of the app-key secret
  - Added validation that the key is exactly 32 characters long, otherwise generate error
  - If a value is defined for `APP_KEY` in `values.yaml`, then take that one, otherwise continue with the already present logic
- Changes to `Chart.yaml`:
  - Bump patch version to `1.7.2`