### PR TITLE
Fix APP_KEY validation to not include newline and whitespace

### DIFF
--- a/charts/firefly-iii/Chart.yaml
+++ b/charts/firefly-iii/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: firefly-iii
-version: 1.7.2
+version: 1.7.3
 description: Installs Firefly III
 type: application
 home: https://www.firefly-iii.org/

--- a/charts/firefly-iii/templates/_helpers.tpl
+++ b/charts/firefly-iii/templates/_helpers.tpl
@@ -85,7 +85,7 @@ Validate if length of APP_KEY is 32 characters
 */}}
 {{- define "firefly-iii.validate-app-key" -}}
   {{ $length := len .Values.secrets.appKey }}
-  {{- if eq 32 $length }}
-    {{ .Values.secrets.appKey }}
+  {{- if eq 32 $length -}}
+    {{- .Values.secrets.appKey -}}
   {{- end -}}
 {{- end -}}

--- a/charts/firefly-iii/values.yaml
+++ b/charts/firefly-iii/values.yaml
@@ -44,7 +44,7 @@ secrets:
     APP_PASSWORD: "CHANGE_ENCRYPT_ME"
     DB_PASSWORD: "CHANGE_ENCRYPT_ME"
   # -- Statically set the APP_KEY in case this is desired over the autogeneration. Should be a random 32-character string.
-  # -- Can be generated using: `openssl rand 32`
+  # -- Can be generated using: `cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1`
   # appKey: "CHANGE_ME"
 
 # -- A cronjob for [recurring Firefly III tasks](https://docs.firefly-iii.org/firefly-iii/advanced-installation/cron/).


### PR DESCRIPTION
When adding `APP_KEY` as a chart value, the validation for the length of the string inadvertingly added a newline and 2 spaces to the base64-encoded string.

This results in the bootstrapping process not to work, due to a misconfigured `APP_KEY`.

This PR resolves this.