### PR TITLE
feat: add possibility to change update strategy

### DIFF
--- a/charts/firefly-iii/Chart.yaml
+++ b/charts/firefly-iii/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: firefly-iii
-version: 1.7.4
+version: 1.8.0
 description: Installs Firefly III
 type: application
 home: https://www.firefly-iii.org/

--- a/charts/firefly-iii/templates/deployment.yaml
+++ b/charts/firefly-iii/templates/deployment.yaml
@@ -8,6 +8,8 @@ spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
+  strategy:
+    type: {{ default "RollingUpdate" .Values.deploymentStrategyType }}
   selector:
     matchLabels:
       {{- include "firefly-iii.selectorLabels" . | nindent 6 }}

--- a/charts/firefly-iii/values.yaml
+++ b/charts/firefly-iii/values.yaml
@@ -1,4 +1,5 @@
 replicaCount: 1
+deploymentStrategyType: RollingUpdate
 
 image:
   repository: "fireflyiii/core"


### PR DESCRIPTION
Changes in this pull request:

- Introduce a configuration option to customize the update strategy. This enhancement is particularly beneficial for scenarios involving ReadWriteOnce (RWO) PersistentVolumeClaims (PVCs), where a PVC can be mounted by only one Pod at a time.
