### PR TITLE
no longer hard code storageClass and don't assume RWX

### DIFF
--- a/charts/firefly-iii-stack/Chart.yaml
+++ b/charts/firefly-iii-stack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: firefly-iii-stack
-version: 0.7.2
+version: 0.7.3
 description: Installs Firefly III stack (db, app, importer)
 type: application
 dependencies:

--- a/charts/firefly-iii-stack/README.md
+++ b/charts/firefly-iii-stack/README.md
@@ -1,6 +1,6 @@
 # firefly-iii-stack
 
-![Version: 0.7.2](https://img.shields.io/badge/Version-0.7.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.7.3](https://img.shields.io/badge/Version-0.7.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Installs Firefly III stack (db, app, importer)
 **Homepage:** <https://github.com/firefly-iii/kubernetes>

--- a/charts/firefly-iii-stack/values.yaml
+++ b/charts/firefly-iii-stack/values.yaml
@@ -7,8 +7,7 @@ firefly-db:
     pullPolicy: IfNotPresent
 
   storage:
-    class: nfs-client
-    accessModes: ReadWriteMany
+    class: ~
     dataSize: 1Gi
 
   # environment variables

--- a/charts/firefly-iii-stack/values.yaml
+++ b/charts/firefly-iii-stack/values.yaml
@@ -8,6 +8,7 @@ firefly-db:
 
   storage:
     class: ~
+    accessModes: ~ # Change as needed for your storageClass https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes
     dataSize: 1Gi
 
   # environment variables

--- a/charts/firefly-iii-stack/values.yaml
+++ b/charts/firefly-iii-stack/values.yaml
@@ -8,7 +8,7 @@ firefly-db:
 
   storage:
     class: ~
-    accessModes: ~ # Change as needed for your storageClass https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes
+    accessModes: ~  # Change as needed for your storageClass https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes
     dataSize: 1Gi
 
   # environment variables


### PR DESCRIPTION
Fixes issue # [8651](https://github.com/firefly-iii/firefly-iii/issues/8651)

Changes in this pull request:

- Remove hardcoded value of storageClass for the db chart inside the stack chart
- Remove ReadWriteMany accessMode hardcode as well, as this will also depend on if the storageClass used supports it
