### PR TITLE
fix: diffrent postgres versions in main container and backup Job

### DIFF
--- a/charts/firefly-db/Chart.yaml
+++ b/charts/firefly-db/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: firefly-db
-version: 0.2.1
+version: 0.2.2
 description: Installs a postgres db for Firefly III
 type: application
 sources:

--- a/charts/firefly-db/README.md
+++ b/charts/firefly-db/README.md
@@ -51,7 +51,7 @@ storage:
 | configs.existingSecret | string | `""` | Set this to the name of a secret to load environment variables from. If defined, values in the secret will override values in configs |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"postgres"` |  |
-| image.tag | string | `"10-alpine"` |  |
+| image.tag | string | `"10-alpine"` | Should containe alpine if you use backup.destination "http" |
 | storage.accessModes | string | `"ReadWriteOnce"` |  |
 | storage.class | string | `nil` |  |
 | storage.dataSize | string | `"1Gi"` |  |

--- a/charts/firefly-db/templates/backup.tpl
+++ b/charts/firefly-db/templates/backup.tpl
@@ -2,7 +2,7 @@
 spec:
   containers:
   - name: {{ template "firefly-db.fullname" . }}-backup-job
-    image: alpine:3.13
+    image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
     imagePullPolicy: IfNotPresent
     envFrom:
     - configMapRef:
@@ -12,13 +12,12 @@ spec:
     - -c
     - |
       set -e
-      apk update
-      apk add curl
-      apk add postgresql
       echo "creating backup file"
       pg_dump -h $DBHOST -p $DBPORT -U $DBUSER --format=p --clean -d $DBNAME > /var/lib/backup/$DBNAME.sql
       ls -la
       {{- if eq .Values.backup.destination "http" }}
+      apk update
+      apk add curl
       echo "uploading backup file"
       curl -F "filename=@/var/lib/backup/${DBNAME}.sql" $BACKUP_URL
       {{- end }}


### PR DESCRIPTION
If the postgres version in alpine repo mismatches the one of the main container the dump fails.
can be tested with values:
```yaml
firefly-db:
    image:
        repository: postgres
        tag: 16.3-alpine
```
possible problem: if main image is not alpine and backup destination is http the curl install fails