### PR TITLE
Support extraVolumes and extraVolumeMounts on db and app

### DIFF
--- a/charts/firefly-db/templates/backup.tpl
+++ b/charts/firefly-db/templates/backup.tpl
@@ -24,15 +24,21 @@ spec:
       {{- end }}
       echo "done"
     volumeMounts:
+      {{- with .Values.backup.extraVolumeMounts }}
+        {{- toYaml . | nindent 10 }}
+      {{- end }}
+      {{- if .Values.backup.pvc.enabled }}
       - name: backup-storage
         mountPath: /var/lib/backup
+      {{- end }}
   restartPolicy: Never
   volumes:
+    {{- with .Values.backup.extraVolumes }}
+      {{- toYaml . | nindent 2 }}
+    {{- end }}
+    {{- if .Values.backup.pvc.enabled }}
     - name: backup-storage
-      {{- if eq .Values.backup.destination "pvc" }}
       persistentVolumeClaim:
         claimName: {{ default (printf "%s-%s" (include "firefly-db.fullname" .) "backup-storage-claim") .Values.backup.pvc.existingClaim }}
-      {{- else }}
-      emptyDir: {}
-      {{- end }}
+    {{- end }}
 {{ end }}

--- a/charts/firefly-db/templates/firefly-backup-pvc.yml
+++ b/charts/firefly-db/templates/firefly-backup-pvc.yml
@@ -1,4 +1,4 @@
-{{- if and (eq .Values.backup.destination "pvc") (eq .Values.backup.pvc.existingClaim "") }}
+{{- if and (.Values.backup.pvc.enabled) (eq .Values.backup.pvc.existingClaim "") }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -10,9 +10,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  {{- with .Values.backup.pvc.class }}
-  storageClassName: {{ . }}
-  {{- end }}
+  storageClassName: {{ .Values.backup.pvc.class }}
   accessModes:
     - {{ .Values.backup.pvc.accessModes }}
   resources:

--- a/charts/firefly-db/templates/firefly-db-deploy.yml
+++ b/charts/firefly-db/templates/firefly-db-deploy.yml
@@ -38,10 +38,29 @@ spec:
             memory: "512Mi"
             cpu: "500m"
         volumeMounts:
+          {{- with .Values.extraVolumeMounts }}
+          {{- toYaml . | nindent 8 }}
+          {{- end }}
+          {{ if .Values.storage.enabled }}
+          {{ if .Values.image.repository | contains "mysql" }}
+          - name: db-storage
+            mountPath: /var/lib/mysql
+            subPath: data
+          {{- end }}
+          {{ if .Values.image.repository | contains "postgres" }}
           - name: db-storage
             mountPath: /var/lib/postgresql/data
             subPath: data
+          {{- end }}
+          {{- end }}
+
       volumes:
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+
+        {{ if .Values.storage.enabled }}
         - name: db-storage
           persistentVolumeClaim:
             claimName: {{ default (printf "%s-%s" (include "firefly-db.fullname" .) "storage-claim") .Values.storage.existingClaim }}
+        {{- end }}

--- a/charts/firefly-db/templates/firefly-db-pvc.yml
+++ b/charts/firefly-db/templates/firefly-db-pvc.yml
@@ -1,4 +1,4 @@
-{{- if eq .Values.storage.existingClaim "" }}
+{{- if and (eq .Values.storage.existingClaim "") .Values.storage.enabled }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/charts/firefly-db/values.yaml
+++ b/charts/firefly-db/values.yaml
@@ -4,6 +4,7 @@ image:
   pullPolicy: IfNotPresent
 
 storage:
+  enabled: true
   class: ~
   accessModes: ReadWriteOnce
   dataSize: 1Gi
@@ -14,11 +15,14 @@ backup:
   # There are two possible backup destinations currently implemented, http and pvc
   destination: http
   pvc:
+    enabled: false
     class: ~
     accessModes: ReadWriteOnce
     dataSize: 1Gi
     # -- Use an existing PersistentVolumeClaim, overrides values above
     existingClaim: ""
+  extraVolumeMounts: []
+  extraVolumes: []
 
 configs:
   RESTORE_URL: ""
@@ -36,3 +40,6 @@ configs:
   existingSecret: ""
 
 backupSchedule: "0 3 * * *"
+
+extraVolumeMounts: []
+extraVolumes: []


### PR DESCRIPTION
This PR introduces the ability to mount additional volumes in both the Firefly-DB deployment and backup jobs. This provides flexibility to attach custom storage solutions or configurations as needed.

- Added extraVolumeMounts and extraVolumes to the templates and values.yaml file to enable custom volume definitions for both the database and backup containers.
- Updated the PVC templates (firefly-db-pvc.yml, firefly-backup-pvc.yml) to include conditionals ensuring PVCs are only created when enabled and no existing claim is provided.


## Example Usage
```yaml
# Firefly III
firefly-iii:

  persistence:
    enabled: false
  extraVolumeMounts:
    - name: firefly-iii-volume
      mountPath: /var/www/html/storage/upload
  extraVolumes:
      - name: firefly-iii-volume
        hostPath:
          path: /home/firefly/storage/upload
          type: DirectoryOrCreate

# DB
firefly-db:
  storage:
    enabled: false

  extraVolumeMounts:
    - name: firefly-db-volume
      mountPath: /var/lib/mysql
  extraVolumes:
    - name: firefly-db-volume
      hostPath:
        path: /home/firefly/db
        type: DirectoryOrCreate
  backup:
    destination: "pvc"
    pvc:
      enabled: false
    extraVolumeMounts:
      - name: firefly-backup-volume
        mountPath: /var/lib/backup
    extraVolumes:
      - name: firefly-backup-volume
        hostPath:
          path: /home/firefly/db-backup
          type: DirectoryOrCreate

```