### PR TITLE
Update readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -31,8 +31,10 @@ helm repo update
 and then install it with
 
 ```sh
-helm install firefly-iii firefly-iii/firefly-iii-stack
+helm install firefly-iii firefly-iii/firefly-iii-stack --set storage.accessModes=ReadWriteOnce
 ```
+
+Change as needed for your storageClass https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes
 
 For detailed documentation on the charts, check out the [`charts` directory in firefly-iii/kubernetes](https://github.com/firefly-iii/kubernetes/tree/main/charts).
 


### PR DESCRIPTION
explicitly set storage.accessMode to `ReadWriteOnce` in the readme. a null value is invalid in k8s version 1.30

this should prevent the following error when installing:

```
Error: INSTALLATION FAILED: 1 error occurred:
        * PersistentVolumeClaim "firefly-iii-firefly-db-storage-claim" is invalid: spec.accessModes: Unsupported value: "": supported values: "ReadOnlyMany", "ReadWriteMany", "ReadWriteOnce", "ReadWriteOncePod"
```