### PR TITLE
Use environment variables from secret on database job.

### DIFF
--- a/charts/firefly-db/Chart.yaml
+++ b/charts/firefly-db/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: firefly-db
-version: 0.2.2
+version: 0.2.3
 description: Installs a postgres db for Firefly III
 type: application
 sources:

--- a/charts/firefly-db/templates/backup.tpl
+++ b/charts/firefly-db/templates/backup.tpl
@@ -5,8 +5,13 @@ spec:
     image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
     imagePullPolicy: IfNotPresent
     envFrom:
+    {{- if not .Values.configs.existingSecret }}
     - configMapRef:
         name: {{ template "firefly-db.fullname" . }}-config
+    {{- else }}
+    - secretRef:
+        name: {{ .Values.configs.existingSecret }}
+    {{- end }}
     command:
     - /bin/sh
     - -c

--- a/charts/firefly-db/templates/firefly-db-cm.yml
+++ b/charts/firefly-db/templates/firefly-db-cm.yml
@@ -1,3 +1,4 @@
+{{- if not .Values.configs.existingSecret }}  
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -11,4 +12,5 @@ metadata:
 data:
 {{- range $key, $value := .Values.configs }}
   {{ $key }}: {{ $value | quote }}
+{{- end }}
 {{- end }}

--- a/charts/firefly-db/templates/firefly-db-restore-job.yml
+++ b/charts/firefly-db/templates/firefly-db-restore-job.yml
@@ -23,8 +23,13 @@ spec:
         image: alpine:3.13
         imagePullPolicy: IfNotPresent
         envFrom:
+        {{- if not .Values.configs.existingSecret }}
         - configMapRef:
             name: {{ template "firefly-db.fullname" . }}-config
+        {{- else }}
+        - secretRef:
+            name: {{ .Values.configs.existingSecret }}
+        {{- end }}
         command: 
         - /bin/sh
         - -c

--- a/charts/firefly-db/values.yaml
+++ b/charts/firefly-db/values.yaml
@@ -9,7 +9,7 @@ storage:
   dataSize: 1Gi
   # -- Use an existing PersistentVolumeClaim, overrides values above
   existingClaim: ""
-  
+
 backup:
   # There are two possible backup destinations currently implemented, http and pvc
   destination: http


### PR DESCRIPTION
### Summary
Database backup job errors to authenticate to database when DB has been configured using `.Values.configs.existingSecret`.

When overriding the credentials using an existing secret that contains different values than the ones present on the default ConfigMap, the job will fail to authenticate the database.


```yaml
firefly-db:
  configs:
     existingSecret: firefly-iii # Variables for, DB*, and POSTGRES* are not  using default values.
```

```bash
OK: 143 MiB in 36 packages
creating backup file
pg_dump: error: connection to database "firefly" failed: FATAL:  password authentication failed for user "firefly"
```

As [templated here](https://github.com/firefly-iii/kubernetes/blob/main/charts/firefly-db/templates/firefly-db-deploy.yml#L26-L32), the database deployments load environments variable from  from the default ConfigMap or a Secret if `.Values.configs.existingSecret` is present. This same logic is not present on the backup job jobspec, which always load environments variables from the configmap. 

### Changes in this pull request:
- Conditional logic to match the database deployment environment variable `envFrom` field on the backup job.
- Same as above for the restore job.
- Do not create the database ConfigMap when `.Values.configs.existingSecret` key is present (Avoid redundancies / misdirection)

### Testing

- [Deploy from updated chart](https://github.com/vicsufer/homelab/commit/6881504b4736b010318fe79f26a28c031763a09d).
- [Testing firefly-stack chart with patched DB chart](https://github.com/vicsufer/firefly-kubernetes/blob/test/charts/firefly-iii-stack/Chart.yaml#L10)

Now the  backup job connects properly to the database, and the configmap is not created.
```bash
$ kubectl get cm -n firefly-iii
NAME                   DATA   AGE
firefly-iii            7      22h
firefly-iii-importer   5      40m
kube-root-ca.crt       1      23h
```

```bash
creating backup file
total 72
drwxr-xr-x    1 root     root          4096 Dec 11 18:17 .
drwxr-xr-x    1 root     root          4096 Dec 11 18:17 ..
drwxr-xr-x    1 root     root          4096 Nov 12  2022 bin
drwxr-xr-x    5 root     root           360 Dec 11 18:17 dev
drwxr-xr-x    2 root     root          4096 Nov 12  2022 docker-entrypoint-initdb.d
lrwxrwxrwx    1 root     root            34 Nov 12  2022 docker-entrypoint.sh -> usr/local/bin/docker-entrypoint.sh
drwxr-xr-x    1 root     root          4096 Dec 11 18:17 etc
drwxr-xr-x    2 root     root          4096 Nov 11  2022 home
drwxr-xr-x    1 root     root          4096 Nov 12  2022 lib
drwxr-xr-x    5 root     root          4096 Nov 11  2022 media
drwxr-xr-x    2 root     root          4096 Nov 11  2022 mnt
drwxr-xr-x    2 root     root          4096 Nov 11  2022 opt
dr-xr-xr-x  505 root     root             0 Dec 11 18:17 proc
drwx------    2 root     root          4096 Nov 11  2022 root
drwxr-xr-x    1 root     root          4096 Dec 11 18:17 run
drwxr-xr-x    1 root     root          4096 Nov 12  2022 sbin
drwxr-xr-x    2 root     root          4096 Nov 11  2022 srv
dr-xr-xr-x   13 root     root             0 Dec 11 18:17 sys
drwxrwxrwt    1 root     root          4096 Nov 12  2022 tmp
drwxr-xr-x    1 root     root          4096 Nov 12  2022 usr
drwxr-xr-x    1 root     root          4096 Nov 12  2022 var
fetch https://dl-cdn.alpinelinux.org/alpine/v3.16/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.16/community/x86_64/APKINDEX.tar.gz
v3.16.9-126-gfdbad9abb99 [https://dl-cdn.alpinelinux.org/alpine/v3.16/main]
v3.16.9-125-gec300a94000 [https://dl-cdn.alpinelinux.org/alpine/v3.16/community]
OK: 17054 distinct packages available
(1/5) Installing ca-certificates (20240226-r0)
(2/5) Installing brotli-libs (1.0.9-r6)
(3/5) Installing nghttp2-libs (1.47.0-r2)
(4/5) Installing libcurl (8.5.0-r0)
(5/5) Installing curl (8.5.0-r0)
Executing busybox-1.35.0-r17.trigger
Executing ca-certificates-20240226-r0.trigger
OK: 55 MiB in 47 packages
uploading backup file
```
