### PR TITLE
Update cronjob name to distinguish it from the main Firefly III pod

### DIFF
--- a/charts/firefly-iii/templates/cronjob.yaml
+++ b/charts/firefly-iii/templates/cronjob.yaml
@@ -7,7 +7,7 @@ apiVersion: batch/v1beta1
 {{- end }}
 kind: CronJob
 metadata:
-  name: {{ include "firefly-iii.fullname" . }}
+  name: {{ include "firefly-iii.fullname" . }}-cronjob
   labels:
     {{- include "firefly-iii.labels" . | nindent 4 }}
     {{- with .Values.labels }}
@@ -42,7 +42,7 @@ spec:
           securityContext: {{- toYaml . | nindent 12 }}
           {{- end }}
           containers:
-            - name: {{ .Chart.Name }}
+            - name: {{ .Chart.Name }}-cronjob
               {{- with .Values.cronjob.securityContext }}
               securityContext: {{- toYaml . | nindent 16 }}
               {{- end }}


### PR DESCRIPTION
<!--
Thank you for submitting new code to Firefly III, or any of the related projects. Please read the following rules carefully.

- Please do not submit solutions for problems that are not already reported in an issue.
- Unfortunately, Firefly III can't be your learning experience. If you're new to all of this, please open an issue first.
- Please do not open PRs to "discuss" possible solutions or to "get feedback" on your code. I simply don't have time for that.
- Pull requests for the MAIN branch will be closed.
- DO NOT include translated strings in your PR.
- PRs (or parts thereof) that only fix issues inside code comments will not be accepted.

If it feels necessary to open an issue first, please do so, before you open a PR.

See also: https://docs.firefly-iii.org/explanation/support/#contributing-code

-->

Fixes issue [#10006](https://github.com/firefly-iii/firefly-iii/issues/10006) in firefly-iii/firefly-iii repository

Changes in this pull request:

- Add '-cronjob' to cronjob and container name 