### PR TITLE
Make probes configurable

### DIFF
--- a/charts/firefly-iii/Chart.yaml
+++ b/charts/firefly-iii/Chart.yaml
@@ -4,7 +4,7 @@ description: Installs Firefly III
 home: https://www.firefly-iii.org/
 icon: https://raw.githubusercontent.com/firefly-iii/firefly-iii/main/.github/assets/img/logo-small.png
 type: application
-version: 1.9.2
+version: 1.9.3
 # renovate: image=docker.io/fireflyiii/core
 appVersion: 6.2.9
 sources:

--- a/charts/firefly-iii/templates/deployment.yaml
+++ b/charts/firefly-iii/templates/deployment.yaml
@@ -80,20 +80,18 @@ spec:
             containerPort: 8080
             protocol: TCP
         livenessProbe:
-          httpGet:
-            path: /health
-            port: http
+          {{- with .Values.livenessProbe }}
+            {{- toYaml . | nindent 10 }}
+          {{- end }}
         readinessProbe:
-          httpGet:
-            path: /health
-            port: http
+          {{- with .Values.readinessProbe }}
+            {{- toYaml . | nindent 10 }}
+          {{- end }}
         startupProbe:
-          httpGet:
-            path: /health
-            port: http
-          # Give the app 30 x 10 = 300s to startup
-          failureThreshold: 30
-          periodSeconds: 10
+          {{- with .Values.startupProbe }}
+            {{- toYaml . | nindent 10 }}
+          {{- end }}
+
         {{- with .Values.resources }}
         resources:
           {{- toYaml . | nindent 12 }}

--- a/charts/firefly-iii/values.yaml
+++ b/charts/firefly-iii/values.yaml
@@ -195,4 +195,3 @@ startupProbe:
   # Give the app 30 x 10 = 300s to startup
   failureThreshold: 30
   periodSeconds: 10
-

--- a/charts/firefly-iii/values.yaml
+++ b/charts/firefly-iii/values.yaml
@@ -177,3 +177,22 @@ extraVolumeMounts: []
   # - name: db-tls-firefly
   #   mountPath: /db-cert
   #   readOnly: true
+
+livenessProbe:
+  httpGet:
+    path: /health
+    port: http
+readinessProbe:
+  httpGet:
+    path: /health
+    port: http
+  initialDelaySeconds: 15
+  timeoutSeconds: 1
+startupProbe:
+  httpGet:
+    path: /health
+    port: http
+  # Give the app 30 x 10 = 300s to startup
+  failureThreshold: 30
+  periodSeconds: 10
+


### PR DESCRIPTION
~Fixes issue # (if relevant)~

Changes in this pull request:

- Moved `livenessProbe`, `readinessProbe` and `startupProbe` to values
- Increased Helm Chart version

I discovered that on low-end devices such as the Raspberry Pi the container takes quite a lot of time to start up and therefore, after just 300 seconds, the container is being marked as not ready / unhealthy.