### PR TITLE
Added the "volumeName" and "selector" from the PVC spec as optional values

### DIFF
--- a/charts/firefly-iii/templates/pvc.yaml
+++ b/charts/firefly-iii/templates/pvc.yaml
@@ -14,4 +14,11 @@ spec:
   resources:
     requests:
       storage: {{ .Values.persistence.storage }}
+  {{- if .Values.persistence.selector }}
+  selector:
+    {{- toYaml .Values.persistence.selector | nindent 4 }}
+  {{- end }}
+  {{- if .Values.persistence.volumeName }}
+  volumeName: {{ .Values.persistence.volumeName | quote }}
+  {{- end }}
 {{- end }}

--- a/charts/firefly-iii/values.yaml
+++ b/charts/firefly-iii/values.yaml
@@ -24,6 +24,10 @@ persistence:
   enabled: true
   storageClassName: ""
   accessModes: ReadWriteOnce
+  # volumeName: your-pv-name
+  # selector:
+  #   matchLabels:
+  #     app: my-app
   storage: 1Gi
   # -- If you want to use an existing claim, set it here
   existingClaim: ""


### PR DESCRIPTION
<!--
Thank you for submitting new code to Firefly III, or any of the related projects. Please read the following rules carefully.

- Please do not submit solutions for problems that are not already reported in an issue.
- Unfortunately, Firefly III can't be your learning experience. If you're new to all of this, please open an issue first.
- Please do not open PRs to "discuss" possible solutions or to "get feedback" on your code. I simply don't have time for that.
- Pull requests for the MAIN branch will be closed.
- DO NOT include translated strings in your PR.
- PRs (or parts thereof) that only fix issues inside code comments will not be accepted.

If it feels necessary to open an issue first, please do so, before you open a PR.

See also: https://docs.firefly-iii.org/explanation/support/#contributing-code

-->
    
This PR fixes the issues where k8s randomly selects a PV to choose from based on what the storageClass has to offer. 

Changes in this pull request:

- Added the "volumeName" and "selector" from the PVC spec as optional values to the helm chart


P.S: I did see the "Pull requests for the MAIN branch will be closed." within the template. I think that's aimed at the main repo, where you use a dev branch? 
