### PR TITLE
Fix incorrect Helm --set path for accessModes in documentation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -31,7 +31,7 @@ helm repo update
 and then install it with
 
 ```sh
-helm install firefly-iii firefly-iii/firefly-iii-stack --set storage.accessModes=ReadWriteOnce
+helm install firefly-iii firefly-iii/firefly-iii-stack --set firefly-db.storage.accessModes=ReadWriteOnce
 ```
 
 Change as needed for your storageClass https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes


### PR DESCRIPTION

This PR fixes issue [#10626](https://github.com/firefly-iii/firefly-iii/issues/10626)

Changes in this pull request:

- Provide correct `--set` parameter in documentation when installing Chart.
