### PR TITLE
Fix hardcoded DBHOST env key in firefly-db Helm Chart

### DIFF
--- a/charts/firefly-db/README.md
+++ b/charts/firefly-db/README.md
@@ -38,7 +38,7 @@ storage:
 | backup.pvc.existingClaim | string | `""` | Use an existing PersistentVolumeClaim, overrides values above |
 | backupSchedule | string | `"0 3 * * *"` |  |
 | configs.BACKUP_URL | string | `""` |  |
-| configs.DBHOST | string | `"firefly-firefly-db"` |  |
+| configs.DBHOST | string | `""` |  |
 | configs.DBNAME | string | `"firefly"` |  |
 | configs.DBPORT | string | `"5432"` |  |
 | configs.DBUSER | string | `"firefly"` |  |

--- a/charts/firefly-db/templates/firefly-db-cm.yml
+++ b/charts/firefly-db/templates/firefly-db-cm.yml
@@ -1,4 +1,4 @@
-{{- if not .Values.configs.existingSecret }}  
+{{- if not .Values.configs.existingSecret }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -11,6 +11,9 @@ metadata:
     heritage: {{ .Release.Service }}
 data:
 {{- range $key, $value := .Values.configs }}
+  {{- if ne $key "DBHOST" }}
   {{ $key }}: {{ $value | quote }}
+  {{- end }}
 {{- end }}
+  DBHOST: {{ (default (include "firefly-db.fullname" .) .Values.configs.DBHOST) | quote }}
 {{- end }}

--- a/charts/firefly-db/values.yaml
+++ b/charts/firefly-db/values.yaml
@@ -24,7 +24,7 @@ configs:
   RESTORE_URL: ""
   BACKUP_URL: ""
   PGPASSWORD: ""
-  DBHOST: "" # -- Default is the name of the postgres service
+  DBHOST: ""  # -- Default is the name of the postgres service
   DBPORT: "5432"
   DBNAME: firefly
   DBUSER: firefly

--- a/charts/firefly-db/values.yaml
+++ b/charts/firefly-db/values.yaml
@@ -24,7 +24,7 @@ configs:
   RESTORE_URL: ""
   BACKUP_URL: ""
   PGPASSWORD: ""
-  DBHOST: firefly-firefly-db
+  DBHOST: "" # -- Default is the name of the postgres service
   DBPORT: "5432"
   DBNAME: firefly
   DBUSER: firefly


### PR DESCRIPTION
This PR fixes issue [#10627](https://github.com/firefly-iii/firefly-iii/issues/10627)

Changes in this pull request:

- If `DBHOST` env key is not defined in `values.yaml` file for `firefly-db` Helm Chart, it sets to the name of the postgres svc (default option).
- If said key is defined, that value will be used.
