### PR TITLE
Fix helm firefly db http backup job with default values

### DIFF
--- a/charts/firefly-db/README.md
+++ b/charts/firefly-db/README.md
@@ -31,7 +31,7 @@ storage:
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| backup.destination | string | `"http"` |  |
+| backup.destination | string | `"pvc"` |  |
 | backup.pvc.accessModes | string | `"ReadWriteOnce"` |  |
 | backup.pvc.class | string | `nil` |  |
 | backup.pvc.dataSize | string | `"1Gi"` |  |

--- a/charts/firefly-db/templates/backup.tpl
+++ b/charts/firefly-db/templates/backup.tpl
@@ -22,13 +22,15 @@ spec:
       ls -la
       {{- if eq .Values.backup.destination "http" }}
       if [ -z "$BACKUP_URL" ]; then
-        echo "ERROR: BACKUP_URL is required when backup.destination is set to 'http'"
-        exit 1
+        echo "ERROR: BACKUP_URL is required when backup.destination is set to 'http'. Backup will not be uploaded, but remain in PVC."
+      else
+        apk update
+        apk add curl
+        echo "uploading backup file"
+        curl -F "filename=@/var/lib/backup/${DBNAME}.sql" $BACKUP_URL || {
+          echo "HTTP upload failed. Backup remains in PVC."
+        }
       fi
-      apk update
-      apk add curl
-      echo "uploading backup file"
-      curl -F "filename=@/var/lib/backup/${DBNAME}.sql" $BACKUP_URL
       {{- end }}
       echo "done"
     volumeMounts:

--- a/charts/firefly-db/templates/backup.tpl
+++ b/charts/firefly-db/templates/backup.tpl
@@ -21,6 +21,10 @@ spec:
       pg_dump -h $DBHOST -p $DBPORT -U $DBUSER --format=p --clean -d $DBNAME > /var/lib/backup/$DBNAME.sql
       ls -la
       {{- if eq .Values.backup.destination "http" }}
+      if [ -z "$BACKUP_URL" ]; then
+        echo "ERROR: BACKUP_URL is required when backup.destination is set to 'http'"
+        exit 1
+      fi
       apk update
       apk add curl
       echo "uploading backup file"

--- a/charts/firefly-db/templates/firefly-db-backup-job.yml
+++ b/charts/firefly-db/templates/firefly-db-backup-job.yml
@@ -13,6 +13,7 @@ metadata:
     "helm.sh/hook-weight": "-5"
     "helm.sh/hook-delete-policy": hook-succeeded
 spec:
+  backoffLimit: 0
   ttlSecondsAfterFinished: 100
   parallelism: 1
   completions: 1

--- a/charts/firefly-db/templates/firefly-db-backup-job.yml
+++ b/charts/firefly-db/templates/firefly-db-backup-job.yml
@@ -1,3 +1,7 @@
+{{- if and (eq .Values.backup.destination "http") (empty .Values.configs.BACKUP_URL) }}
+{{- fail "BACKUP_URL must be set when backup.destination is 'http'" }}
+{{- end }}
+
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/charts/firefly-db/templates/firefly-db-cron-backup.yml
+++ b/charts/firefly-db/templates/firefly-db-cron-backup.yml
@@ -15,6 +15,7 @@ spec:
   failedJobsHistoryLimit: 1
   jobTemplate:
     spec:
+      backoffLimit: 0
       template:
         {{- include "backupJobSpec" . | indent 8 }}
 {{ end }}

--- a/charts/firefly-db/values.yaml
+++ b/charts/firefly-db/values.yaml
@@ -12,7 +12,7 @@ storage:
 
 backup:
   # There are two possible backup destinations currently implemented, http and pvc
-  destination: http
+  destination: pvc
   pvc:
     class: ~
     accessModes: ReadWriteOnce
@@ -22,7 +22,7 @@ backup:
 
 configs:
   RESTORE_URL: ""
-  BACKUP_URL: ""
+  BACKUP_URL: ""  # -- Must have value if backup.destination is set to http
   PGPASSWORD: ""
   DBHOST: firefly-firefly-db
   DBPORT: "5432"


### PR DESCRIPTION

    
This PR fixes issue [#10628](https://github.com/firefly-iii/firefly-iii/issues/10628).

Changes in this pull request:
- Chart installation will fail if key `backup.destinaton` is set to `http` and `BACKUP_URL` is set to `""`.
- Defaults `backup.destination` key to `pvc`.
- Allows backup job to complete if `http` backup upload fails. Dump can still be recovered from the pvc.
