### PR TITLE
Fix typo 'Amsterdan' in friefly-db chart values.yaml

### DIFF
--- a/charts/firefly-db/README.md
+++ b/charts/firefly-db/README.md
@@ -47,7 +47,7 @@ storage:
 | configs.POSTGRES_PASSWORD | string | `""` |  |
 | configs.POSTGRES_USER | string | `"firefly"` |  |
 | configs.RESTORE_URL | string | `""` |  |
-| configs.TZ | string | `"Europe/Amsterdan"` |  |
+| configs.TZ | string | `"Europe/Amsterdam"` |  |
 | configs.existingSecret | string | `""` | Set this to the name of a secret to load environment variables from. If defined, values in the secret will override values in configs |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"postgres"` |  |

--- a/charts/firefly-db/values.yaml
+++ b/charts/firefly-db/values.yaml
@@ -28,7 +28,7 @@ configs:
   DBPORT: "5432"
   DBNAME: firefly
   DBUSER: firefly
-  TZ: Europe/Amsterdan
+  TZ: Europe/Amsterdam
   POSTGRES_HOST_AUTH_METHOD: trust
   POSTGRES_USER: firefly
   POSTGRES_PASSWORD: ""


### PR DESCRIPTION
No issue related.

Changes in this pull request:

- Fixes typo 'Amsterdan' to 'Amsterdam' in firefly-db Helm Chart.