### PR TITLE
Bump core and data-importer versions

### DIFF
--- a/charts/firefly-iii-stack/Chart.yaml
+++ b/charts/firefly-iii-stack/Chart.yaml
@@ -4,18 +4,18 @@ description: Installs Firefly III stack (db, app, importer)
 home: https://github.com/firefly-iii/kubernetes
 icon: https://raw.githubusercontent.com/firefly-iii/firefly-iii/main/.github/assets/img/logo-small.png
 type: application
-version: 0.8.8
+version: 0.9.0
 dependencies:
   - name: firefly-db
     version: 0.2.9
     condition: firefly-db.enabled
     repository: file://../firefly-db
   - name: firefly-iii
-    version: 1.9.10
+    version: 1.9.11
     condition: firefly-iii.enabled
     repository: file://../firefly-iii
   - name: importer
-    version: 1.4.9
+    version: 1.5.0
     condition: importer.enabled
     repository: file://../importer
 sources:

--- a/charts/firefly-iii-stack/README.md
+++ b/charts/firefly-iii-stack/README.md
@@ -1,6 +1,6 @@
 # firefly-iii-stack
 
-![Version: 0.8.8](https://img.shields.io/badge/Version-0.8.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.9.0](https://img.shields.io/badge/Version-0.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Installs Firefly III stack (db, app, importer)
 **Homepage:** <https://github.com/firefly-iii/kubernetes>
@@ -17,8 +17,8 @@ Installs Firefly III stack (db, app, importer)
 | Repository | Name | Version |
 |------------|------|---------|
 | file://../firefly-db | firefly-db | 0.2.9 |
-| file://../firefly-iii | firefly-iii | 1.9.10 |
-| file://../importer | importer | 1.4.9 |
+| file://../firefly-iii | firefly-iii | 1.9.11 |
+| file://../importer | importer | 1.5.0 |
 
 ## Upgrading
 

--- a/charts/firefly-iii/Chart.yaml
+++ b/charts/firefly-iii/Chart.yaml
@@ -4,9 +4,9 @@ description: Installs Firefly III
 home: https://www.firefly-iii.org/
 icon: https://raw.githubusercontent.com/firefly-iii/firefly-iii/main/.github/assets/img/logo-small.png
 type: application
-version: 1.9.10
+version: 1.9.11
 # renovate: image=docker.io/fireflyiii/core
-appVersion: 6.2.12
+appVersion: 6.2.21
 sources:
   - https://github.com/firefly-iii/firefly-iii/
 maintainers:

--- a/charts/firefly-iii/README.md
+++ b/charts/firefly-iii/README.md
@@ -1,6 +1,6 @@
 # firefly-iii
 
-![Version: 1.9.10](https://img.shields.io/badge/Version-1.9.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 6.2.12](https://img.shields.io/badge/AppVersion-6.2.12-informational?style=flat-square)
+![Version: 1.9.11](https://img.shields.io/badge/Version-1.9.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 6.2.21](https://img.shields.io/badge/AppVersion-6.2.21-informational?style=flat-square)
 
 Installs Firefly III
 **Homepage:** <https://www.firefly-iii.org/>

--- a/charts/importer/Chart.yaml
+++ b/charts/importer/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: importer
-version: 1.4.9
+version: 1.5.0
 description: Deploys the importer chart for Firefly III
 type: application
 home: https://www.firefly-iii.org/

--- a/charts/importer/README.md
+++ b/charts/importer/README.md
@@ -1,6 +1,6 @@
 # importer
 
-![Version: 1.4.9](https://img.shields.io/badge/Version-1.4.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 1.5.0](https://img.shields.io/badge/Version-1.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Deploys the importer chart for Firefly III
 **Homepage:** <https://www.firefly-iii.org/>
@@ -48,7 +48,7 @@ When a release introduces breaking changes, this section outlines the manual act
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"fireflyiii/data-importer"` |  |
-| image.tag | string | `"version-1.6.2"` |  |
+| image.tag | string | `"version-1.7.8"` |  |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |
 | ingress.className | string | `""` |  |

--- a/charts/importer/values.yaml
+++ b/charts/importer/values.yaml
@@ -46,7 +46,7 @@ additionalVolumes: []
 image:
   repository: fireflyiii/data-importer
   pullPolicy: IfNotPresent
-  tag: "version-1.6.2"
+  tag: "version-1.7.8"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/kustomize/firefly-iii-importer.yaml
+++ b/kustomize/firefly-iii-importer.yaml
@@ -34,7 +34,7 @@ spec:
         tier: frontend
     spec:
       containers:
-      - image: fireflyiii/data-importer:version-1.6.2
+      - image: fireflyiii/data-importer:version-1.7.8
         name: firefly-iii-importer
         env:
         - name: FIREFLY_III_ACCESS_TOKEN

--- a/kustomize/firefly-iii.yaml
+++ b/kustomize/firefly-iii.yaml
@@ -52,7 +52,7 @@ spec:
         tier: frontend
     spec:
       containers:
-      - image: fireflyiii/core:version-6.2.12
+      - image: fireflyiii/core:version-6.2.21
         name: firefly-iii
         env:
         - name: APP_ENV


### PR DESCRIPTION
Fixes issue # (if relevant) None

Changes in this pull request:

Update core to 6.2.21
Update data-importer to 1.7.8

Since there's a minor update on data-importer, I bumped the minor also for the importer chart to 1.5.0