### PR TITLE
Show backup files

### DIFF
--- a/charts/firefly-db/templates/backup.tpl
+++ b/charts/firefly-db/templates/backup.tpl
@@ -25,8 +25,9 @@ spec:
         rm "$(ls -1t /var/lib/backup/$DBNAME-*.sql.gz | tail -1)" || exit 1
         sync
       done
+      df -h /var/lib/backup/
       {{- end }}
-      ls -la
+      ls -la /var/lib/backup/
       {{- if eq .Values.backup.destination "http" }}
       if [ -z "$BACKUP_URL" ]; then
         echo "ERROR: BACKUP_URL is required when backup.destination is set to 'http'. Backup will not be uploaded, but remain in PVC."


### PR DESCRIPTION
Changes in this pull request:
- Fix ls -la command showing root files, not backup ones
- Added df in PVC mode to show volume usage

Example of current output :
```
# kubectl logs pod/db-firefly-db-backup-29495700-j99pg
creating backup file
total 72
drwxr-xr-x    1 root     root          4096 Jan 30 04:00 .
drwxr-xr-x    1 root     root          4096 Jan 30 04:00 ..
drwxr-xr-x    1 root     root          4096 Nov 12  2022 bin
drwxr-xr-x    5 root     root           360 Jan 30 04:00 dev
drwxr-xr-x    2 root     root          4096 Nov 12  2022 docker-entrypoint-initdb.d
lrwxrwxrwx    1 root     root            34 Nov 12  2022 docker-entrypoint.sh -> usr/local/bin/docker-entrypoint.sh
drwxr-xr-x    1 root     root          4096 Jan 30 04:00 etc
drwxr-xr-x    2 root     root          4096 Nov 11  2022 home
drwxr-xr-x    1 root     root          4096 Nov 12  2022 lib
drwxr-xr-x    5 root     root          4096 Nov 11  2022 media
drwxr-xr-x    2 root     root          4096 Nov 11  2022 mnt
drwxr-xr-x    2 root     root          4096 Nov 11  2022 opt
dr-xr-xr-x  293 root     root             0 Jan 30 04:00 proc
drwx------    2 root     root          4096 Nov 11  2022 root
drwxr-xr-x    1 root     root          4096 Jan 30 04:00 run
drwxr-xr-x    1 root     root          4096 Nov 12  2022 sbin
drwxr-xr-x    2 root     root          4096 Nov 11  2022 srv
dr-xr-xr-x   13 root     root             0 Jan 30 04:00 sys
drwxrwxrwt    1 root     root          4096 Nov 12  2022 tmp
drwxr-xr-x    1 root     root          4096 Nov 12  2022 usr
drwxr-xr-x    1 root     root          4096 Nov 12  2022 var
done
```

Expected result :
```
# kubectl logs pod/test-skk69
creating backup file
Filesystem                Size      Used Available Use% Mounted on
/dev/sdc                973.4M    528.0K    956.9M   0% /var/lib/backup
total 528
drwxr-xr-x    3 root     root          4096 Jan 30 09:10 .
drwxr-xr-x    1 root     root          4096 Jan 30 09:09 ..
-rw-r--r--    1 root     root         59078 Jan 30 04:00 firefly-2026-01-30T04:00:07+01:00.sql.gz
-rw-r--r--    1 root     root         59078 Jan 30 09:10 firefly-2026-01-30T09:10:01+01:00.sql.gz
-rw-r--r--    1 root     root        390577 Jan 30 09:10 firefly.sql
drwx------    2 root     root         16384 Jan 29 19:08 lost+found
done
```