### PR TITLE
feat(backup-restore): Add flags to allow disable backup/restore hook …

### DIFF
--- a/charts/firefly-db/README.md
+++ b/charts/firefly-db/README.md
@@ -37,6 +37,7 @@ storage:
 | backup.pvc.dataSize | string | `"1Gi"` |  |
 | backup.pvc.existingClaim | string | `""` | Use an existing PersistentVolumeClaim, overrides values above |
 | backupSchedule | string | `"0 3 * * *"` |  |
+| configs.BACKUP_ENABLED | bool | `true` | Enable backup hook job |
 | configs.BACKUP_URL | string | `""` |  |
 | configs.DBHOST | string | `""` |  |
 | configs.DBNAME | string | `"firefly"` |  |
@@ -46,6 +47,7 @@ storage:
 | configs.POSTGRES_HOST_AUTH_METHOD | string | `"trust"` |  |
 | configs.POSTGRES_PASSWORD | string | `""` |  |
 | configs.POSTGRES_USER | string | `"firefly"` |  |
+| configs.RESTORE_ENABLED | bool | `true` | Enable restore hook job |
 | configs.RESTORE_URL | string | `""` |  |
 | configs.TZ | string | `"Europe/Amsterdam"` |  |
 | configs.existingSecret | string | `""` | Set this to the name of a secret to load environment variables from. If defined, values in the secret will override values in configs |

--- a/charts/firefly-db/templates/firefly-db-backup-job.yml
+++ b/charts/firefly-db/templates/firefly-db-backup-job.yml
@@ -1,3 +1,4 @@
+{{- if .Values.configs.BACKUP_ENABLED }}
 {{- if and (eq .Values.backup.destination "http") (empty .Values.configs.BACKUP_URL) }}
 {{- fail "BACKUP_URL must be set when backup.destination is 'http'" }}
 {{- end }}
@@ -23,3 +24,4 @@ spec:
   completions: 1
   template:
     {{- include "backupJobSpec" . | indent 4 }}
+{{- end }}

--- a/charts/firefly-db/templates/firefly-db-restore-job.yml
+++ b/charts/firefly-db/templates/firefly-db-restore-job.yml
@@ -1,3 +1,4 @@
+{{- if .Values.configs.RESTORE_ENABLED }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -57,3 +58,4 @@ spec:
           {{- else }}
           emptyDir: {}
           {{- end }}
+{{- end }}

--- a/charts/firefly-db/values.yaml
+++ b/charts/firefly-db/values.yaml
@@ -21,6 +21,8 @@ backup:
     existingClaim: ""
 
 configs:
+  RESTORE_ENABLED: true
+  BACKUP_ENABLED: true
   RESTORE_URL: ""
   BACKUP_URL: ""  # -- Must have value if backup.destination is set to http
   PGPASSWORD: ""


### PR DESCRIPTION
<!--
Thank you for submitting new code to Firefly III, or any of the related projects. Please read the following rules carefully.

- Please do not submit solutions for problems that are not already reported in an issue.
- Unfortunately, Firefly III can't be your learning experience. If you're new to all of this, please open an issue first.
- Please do not open PRs to "discuss" possible solutions or to "get feedback" on your code. I simply don't have time for that.
- DO NOT include translated strings in your PR.
- PRs (or parts thereof) that only fix issues inside code comments will not be accepted.

If it feels necessary to open an issue first, please do so, before you open a PR.

See also: https://docs.firefly-iii.org/explanation/support/#contributing-code

-->
    
This PR fixes issue https://github.com/firefly-iii/firefly-iii/issues/12134.

Changes in this pull request:

- Add a flag to allow disable DB backup/restore jobs. The flag does not change any behavior of existing deployments.
