### PR TITLE
Explicitly map the port cronjob uses

### DIFF
--- a/charts/firefly-iii-stack/Chart.yaml
+++ b/charts/firefly-iii-stack/Chart.yaml
@@ -4,14 +4,14 @@ description: Installs Firefly III stack (db, app, importer)
 home: https://github.com/firefly-iii/kubernetes
 icon: https://raw.githubusercontent.com/firefly-iii/firefly-iii/main/.github/assets/img/logo-small.png
 type: application
-version: 0.9.2
+version: 0.9.3
 dependencies:
   - name: firefly-db
     version: 0.2.10
     condition: firefly-db.enabled
     repository: file://../firefly-db
   - name: firefly-iii
-    version: 1.9.13
+    version: 1.9.14
     condition: firefly-iii.enabled
     repository: file://../firefly-iii
   - name: importer

--- a/charts/firefly-iii/Chart.yaml
+++ b/charts/firefly-iii/Chart.yaml
@@ -4,7 +4,7 @@ description: Installs Firefly III
 home: https://www.firefly-iii.org/
 icon: https://raw.githubusercontent.com/firefly-iii/firefly-iii/main/.github/assets/img/logo-small.png
 type: application
-version: 1.9.13
+version: 1.9.14
 # renovate: image=docker.io/fireflyiii/core
 appVersion: 6.5.9
 sources:

--- a/charts/firefly-iii/templates/cronjob.yaml
+++ b/charts/firefly-iii/templates/cronjob.yaml
@@ -71,7 +71,7 @@ spec:
                 - --silent
                 - --show-error
                 - --fail
-                - "http://{{ include "firefly-iii.fullname" . }}/api/v1/cron/$(FIREFLY_III_TOKEN)"
+                - "http://{{ include "firefly-iii.fullname" . }}:{{ .Values.service.port }}/api/v1/cron/$(FIREFLY_III_TOKEN)"
               {{- with .Values.cronjob.resources }}
               resources: {{- toYaml . | nindent 16 }}
               {{- end }}


### PR DESCRIPTION
<!--
Thank you for submitting new code to Firefly III, or any of the related projects. Please read the following rules carefully.

- Please do not submit solutions for problems that are not already reported in an issue.
- Unfortunately, Firefly III can't be your learning experience. If you're new to all of this, please open an issue first.
- Please do not open PRs to "discuss" possible solutions or to "get feedback" on your code. I simply don't have time for that.
- DO NOT include translated strings in your PR.
- PRs (or parts thereof) that only fix issues inside code comments will not be accepted.

If it feels necessary to open an issue first, please do so, before you open a PR.

See also: https://docs.firefly-iii.org/explanation/support/#contributing-code

-->
    
This PR fixes issue # (if relevant).

Changes in this pull request:

- Map the service port that is used by the helm values to the cronjob. Having the variable on 1 side and relying on the default curl port breaks the current connection
- Closes https://github.com/firefly-iii/firefly-iii/issues/12295
-
