### PR TITLE
Add Gateway API support to importer

### DIFF
--- a/charts/firefly-iii-stack/Chart.yaml
+++ b/charts/firefly-iii-stack/Chart.yaml
@@ -15,7 +15,7 @@ dependencies:
     condition: firefly-iii.enabled
     repository: file://../firefly-iii
   - name: importer
-    version: 1.5.2
+    version: 1.6.0
     condition: importer.enabled
     repository: file://../importer
 sources:

--- a/charts/firefly-iii-stack/README.md
+++ b/charts/firefly-iii-stack/README.md
@@ -18,7 +18,7 @@ Installs Firefly III stack (db, app, importer)
 |------------|------|---------|
 | file://../firefly-db | firefly-db | 0.2.10 |
 | file://../firefly-iii | firefly-iii | 1.9.14 |
-| file://../importer | importer | 1.5.2 |
+| file://../importer | importer | 1.6.0 |
 
 ## Upgrading
 

--- a/charts/importer/Chart.yaml
+++ b/charts/importer/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: importer
-version: 1.5.2
+version: 1.6.0
 appVersion: version-2.2.3
 description: Deploys the importer chart for Firefly III
 type: application

--- a/charts/importer/README.md
+++ b/charts/importer/README.md
@@ -1,6 +1,6 @@
 # importer
 
-![Version: 1.5.2](https://img.shields.io/badge/Version-1.5.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: version-2.2.3](https://img.shields.io/badge/AppVersion-version--2.2.3-informational?style=flat-square)
+![Version: 1.6.0](https://img.shields.io/badge/Version-1.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: version-2.2.3](https://img.shields.io/badge/AppVersion-version--2.2.3-informational?style=flat-square)
 
 Deploys the importer chart for Firefly III
 **Homepage:** <https://www.firefly-iii.org/>

--- a/charts/importer/README.md
+++ b/charts/importer/README.md
@@ -46,6 +46,10 @@ When a release introduces breaking changes, this section outlines the manual act
 | fireflyiii.url | string | `"http://firefly-firefly-iii:80"` | The URL at which Firefly III is available. If you change this value, click the "Reauthenticate" button on the importer after opening it! |
 | fireflyiii.vanityUrl | string | `""` | The URL at which you access Firefly III. Check https://docs.firefly-iii.org/data-importer/install/configure/#configure-fidi to find out if you should set this. |
 | fullnameOverride | string | `""` |  |
+| httpRoute.annotations | object | `{}` |  |
+| httpRoute.enabled | bool | `true` |  |
+| httpRoute.hosts | list | `[]` |  |
+| httpRoute.parentRefs | list | `[]` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"fireflyiii/data-importer"` |  |
 | image.tag | string | `""` |  |

--- a/charts/importer/README.md
+++ b/charts/importer/README.md
@@ -47,8 +47,8 @@ When a release introduces breaking changes, this section outlines the manual act
 | fireflyiii.vanityUrl | string | `""` | The URL at which you access Firefly III. Check https://docs.firefly-iii.org/data-importer/install/configure/#configure-fidi to find out if you should set this. |
 | fullnameOverride | string | `""` |  |
 | httpRoute.annotations | object | `{}` |  |
-| httpRoute.enabled | bool | `true` |  |
-| httpRoute.hosts | list | `[]` |  |
+| httpRoute.enabled | bool | `false` |  |
+| httpRoute.hostnames | list | `[]` |  |
 | httpRoute.parentRefs | list | `[]` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"fireflyiii/data-importer"` |  |

--- a/charts/importer/templates/httproute.yaml
+++ b/charts/importer/templates/httproute.yaml
@@ -10,8 +10,8 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  hosts:
-    {{- range .Values.httpRoute.hosts }}
+  hostnames:
+    {{- range .Values.httpRoute.hostnames }}
     - {{ . | quote }}
     {{- end }}
   parentRefs:

--- a/charts/importer/templates/httproute.yaml
+++ b/charts/importer/templates/httproute.yaml
@@ -22,7 +22,7 @@ spec:
     - backendRefs:
         - kind: Service
           name: {{ include "importer.fullname" . }}
-          port: 8080
+          port: {{ .Values.service.port }}
           weight: 1
       matches:
         - path:

--- a/charts/importer/templates/httproute.yaml
+++ b/charts/importer/templates/httproute.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.httpRoute.enabled -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "importer.fullname" . }}
+  labels:
+    {{- include "importer.labels" . | nindent 4 }}
+  {{- with .Values.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  hosts:
+    {{- range .Values.httpRoute.hosts }}
+    - {{ . | quote }}
+    {{- end }}
+  parentRefs:
+    {{- range .Values.httpRoute.parentRefs }}
+    - {{ toYaml . | nindent 6 }}
+    {{- end }}
+  rules:
+    - backendRefs:
+        - kind: Service
+          name: {{ include "importer.fullname" . }}
+          port: 8080
+          weight: 1
+      matches:
+        - path:
+            type: PathPrefix
+            value: /
+{{- end -}}

--- a/charts/importer/templates/httproute.yaml
+++ b/charts/importer/templates/httproute.yaml
@@ -11,13 +11,9 @@ metadata:
   {{- end }}
 spec:
   hostnames:
-    {{- range .Values.httpRoute.hostnames }}
-    - {{ . | quote }}
-    {{- end }}
+    {{- toYaml .Values.httpRoute.hostnames | nindent 4 }}
   parentRefs:
-    {{- range .Values.httpRoute.parentRefs }}
-    - {{ toYaml . | nindent 6 }}
-    {{- end }}
+    {{- toYaml .Values.httpRoute.parentRefs | nindent 4 }}
   rules:
     - backendRefs:
         - kind: Service

--- a/charts/importer/values.yaml
+++ b/charts/importer/values.yaml
@@ -105,7 +105,7 @@ ingress:
   #      - chart-example.local
 
 httpRoute:
-  enabled: true
+  enabled: false
   annotations: {}
   hosts: []
   parentRefs: []

--- a/charts/importer/values.yaml
+++ b/charts/importer/values.yaml
@@ -107,7 +107,7 @@ ingress:
 httpRoute:
   enabled: false
   annotations: {}
-  hosts: []
+  hostnames: []
   parentRefs: []
 
 resources: {}

--- a/charts/importer/values.yaml
+++ b/charts/importer/values.yaml
@@ -104,6 +104,12 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
+httpRoute:
+  enabled: true
+  annotations: {}
+  hosts: []
+  parentRefs: []
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
Add support for Kubernetes Gateway API to the data importer chart by adding an HTTPRoute resource (disabled by default) that routes traffic to the existing Service.

I tested this feature locally in my K8s cluster.