### PR TITLE
Make rolling update configurable

### DIFF
--- a/charts/firefly-iii-stack/Chart.yaml
+++ b/charts/firefly-iii-stack/Chart.yaml
@@ -4,14 +4,14 @@ description: Installs Firefly III stack (db, app, importer)
 home: https://github.com/firefly-iii/kubernetes
 icon: https://raw.githubusercontent.com/firefly-iii/firefly-iii/main/.github/assets/img/logo-small.png
 type: application
-version: 0.9.3
+version: 0.9.4
 dependencies:
   - name: firefly-db
     version: 0.2.10
     condition: firefly-db.enabled
     repository: file://../firefly-db
   - name: firefly-iii
-    version: 1.9.14
+    version: 1.9.15
     condition: firefly-iii.enabled
     repository: file://../firefly-iii
   - name: importer

--- a/charts/firefly-iii-stack/README.md
+++ b/charts/firefly-iii-stack/README.md
@@ -1,6 +1,6 @@
 # firefly-iii-stack
 
-![Version: 0.9.3](https://img.shields.io/badge/Version-0.9.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.9.4](https://img.shields.io/badge/Version-0.9.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Installs Firefly III stack (db, app, importer)
 **Homepage:** <https://github.com/firefly-iii/kubernetes>
@@ -17,7 +17,7 @@ Installs Firefly III stack (db, app, importer)
 | Repository | Name | Version |
 |------------|------|---------|
 | file://../firefly-db | firefly-db | 0.2.10 |
-| file://../firefly-iii | firefly-iii | 1.9.14 |
+| file://../firefly-iii | firefly-iii | 1.9.15 |
 | file://../importer | importer | 1.6.0 |
 
 ## Upgrading

--- a/charts/firefly-iii/Chart.yaml
+++ b/charts/firefly-iii/Chart.yaml
@@ -4,7 +4,7 @@ description: Installs Firefly III
 home: https://www.firefly-iii.org/
 icon: https://raw.githubusercontent.com/firefly-iii/firefly-iii/main/.github/assets/img/logo-small.png
 type: application
-version: 1.9.14
+version: 1.9.15
 # renovate: image=docker.io/fireflyiii/core
 appVersion: 6.5.9
 sources:

--- a/charts/firefly-iii/README.md
+++ b/charts/firefly-iii/README.md
@@ -139,6 +139,8 @@ ingress:
 | readinessProbe.timeoutSeconds | int | `1` |  |
 | replicaCount | int | `1` |  |
 | resources | object | `{}` |  |
+| rollingUpdate.maxSurge | string | `"25%"` |  |
+| rollingUpdate.maxUnavailable | string | `"25%"` |  |
 | secrets | object | `{"env":{"APP_PASSWORD":"CHANGE_ENCRYPT_ME","DB_PASSWORD":"CHANGE_ENCRYPT_ME"}}` | Create a new Secret from values file to store sensitive environment variables. Make sure to keep your secrets encrypted in the repository! For example, you can use the 'helm secrets' plugin (https://github.com/jkroepke/helm-secrets) to encrypt and manage secrets. If the 'config.existingSecret' value is set, a new Secret will not be created. |
 | securityContext | object | `{}` |  |
 | service.port | int | `80` |  |

--- a/charts/firefly-iii/README.md
+++ b/charts/firefly-iii/README.md
@@ -1,6 +1,6 @@
 # firefly-iii
 
-![Version: 1.9.14](https://img.shields.io/badge/Version-1.9.14-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 6.5.9](https://img.shields.io/badge/AppVersion-6.5.9-informational?style=flat-square)
+![Version: 1.9.15](https://img.shields.io/badge/Version-1.9.15-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 6.5.9](https://img.shields.io/badge/AppVersion-6.5.9-informational?style=flat-square)
 
 Installs Firefly III
 **Homepage:** <https://www.firefly-iii.org/>

--- a/charts/firefly-iii/templates/deployment.yaml
+++ b/charts/firefly-iii/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- $deploymentStrategyType := default "RollingUpdate" .Values.deploymentStrategyType -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -9,7 +10,10 @@ spec:
   replicas: {{ .Values.replicaCount }}
   {{- end }}
   strategy:
-    type: {{ default "RollingUpdate" .Values.deploymentStrategyType }}
+    type: {{ $deploymentStrategyType }}
+    {{- if (eq $deploymentStrategyType "RollingUpdate") }}
+    rollingUpdate: {{- toYaml .Values.rollingUpdate | nindent 6 }}
+    {{- end }}
   selector:
     matchLabels:
       {{- include "firefly-iii.selectorLabels" . | nindent 6 }}

--- a/charts/firefly-iii/values.yaml
+++ b/charts/firefly-iii/values.yaml
@@ -7,6 +7,9 @@ global:
 
 replicaCount: 1
 deploymentStrategyType: RollingUpdate
+rollingUpdate:
+  maxSurge: 25%
+  maxUnavailable: 25%
 
 image:
   registry: "docker.io"


### PR DESCRIPTION
Make rolling update configurable.

Currently, it cannot be changed from the default config of `maxSurge` 25% and `maxUnavailable` 25%.