### PR TITLE
Add Gateway API HTTPRoute support to the firefly-iii chart

### DIFF
--- a/charts/firefly-iii-stack/Chart.yaml
+++ b/charts/firefly-iii-stack/Chart.yaml
@@ -11,7 +11,7 @@ dependencies:
     condition: firefly-db.enabled
     repository: file://../firefly-db
   - name: firefly-iii
-    version: 1.9.17
+    version: 1.10.0
     condition: firefly-iii.enabled
     repository: file://../firefly-iii
   - name: importer

--- a/charts/firefly-iii-stack/Chart.yaml
+++ b/charts/firefly-iii-stack/Chart.yaml
@@ -4,7 +4,7 @@ description: Installs Firefly III stack (db, app, importer)
 home: https://github.com/firefly-iii/kubernetes
 icon: https://raw.githubusercontent.com/firefly-iii/firefly-iii/main/.github/assets/img/logo-small.png
 type: application
-version: 0.9.6
+version: 0.10.0
 dependencies:
   - name: firefly-db
     version: 0.2.10

--- a/charts/firefly-iii-stack/README.md
+++ b/charts/firefly-iii-stack/README.md
@@ -1,6 +1,6 @@
 # firefly-iii-stack
 
-![Version: 0.9.6](https://img.shields.io/badge/Version-0.9.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.10.0](https://img.shields.io/badge/Version-0.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Installs Firefly III stack (db, app, importer)
 **Homepage:** <https://github.com/firefly-iii/kubernetes>

--- a/charts/firefly-iii-stack/README.md
+++ b/charts/firefly-iii-stack/README.md
@@ -17,7 +17,7 @@ Installs Firefly III stack (db, app, importer)
 | Repository | Name | Version |
 |------------|------|---------|
 | file://../firefly-db | firefly-db | 0.2.10 |
-| file://../firefly-iii | firefly-iii | 1.9.17 |
+| file://../firefly-iii | firefly-iii | 1.10.0 |
 | file://../importer | importer | 1.6.0 |
 
 ## Upgrading

--- a/charts/firefly-iii/Chart.yaml
+++ b/charts/firefly-iii/Chart.yaml
@@ -4,7 +4,7 @@ description: Installs Firefly III
 home: https://www.firefly-iii.org/
 icon: https://raw.githubusercontent.com/firefly-iii/firefly-iii/main/.github/assets/img/logo-small.png
 type: application
-version: 1.9.17
+version: 1.10.0
 # renovate: image=docker.io/fireflyiii/core
 appVersion: 6.5.9
 sources:

--- a/charts/firefly-iii/README.md
+++ b/charts/firefly-iii/README.md
@@ -1,6 +1,6 @@
 # firefly-iii
 
-![Version: 1.9.17](https://img.shields.io/badge/Version-1.9.17-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 6.5.9](https://img.shields.io/badge/AppVersion-6.5.9-informational?style=flat-square)
+![Version: 1.10.0](https://img.shields.io/badge/Version-1.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 6.5.9](https://img.shields.io/badge/AppVersion-6.5.9-informational?style=flat-square)
 
 Installs Firefly III
 **Homepage:** <https://www.firefly-iii.org/>
@@ -112,6 +112,10 @@ ingress:
 | fullnameOverride | string | `""` |  |
 | global.image.pullPolicy | string | `nil` | if set it will overwrite all pullPolicy |
 | global.image.registry | string | `nil` | if set it will overwrite all registry entries |
+| httpRoute.annotations | object | `{}` |  |
+| httpRoute.enabled | bool | `false` |  |
+| httpRoute.hostnames | list | `[]` |  |
+| httpRoute.parentRefs | list | `[]` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.registry | string | `"docker.io"` |  |
 | image.repository | string | `"fireflyiii/core"` |  |

--- a/charts/firefly-iii/templates/httproute.yaml
+++ b/charts/firefly-iii/templates/httproute.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.httpRoute.enabled -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "firefly-iii.fullname" . }}
+  labels:
+    {{- include "firefly-iii.labels" . | nindent 4 }}
+  {{- with .Values.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  hostnames:
+    {{- toYaml .Values.httpRoute.hostnames | nindent 4 }}
+  parentRefs:
+    {{- toYaml .Values.httpRoute.parentRefs | nindent 4 }}
+  rules:
+    - backendRefs:
+        - kind: Service
+          name: {{ include "firefly-iii.fullname" . }}
+          port: {{ .Values.service.port }}
+          weight: 1
+      matches:
+        - path:
+            type: PathPrefix
+            value: /
+{{- end -}}

--- a/charts/firefly-iii/values.yaml
+++ b/charts/firefly-iii/values.yaml
@@ -152,6 +152,12 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
+httpRoute:
+  enabled: false
+  annotations: {}
+  hostnames: []
+  parentRefs: []
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
Adds an opt-in HTTPRoute template (Gateway API) to the `firefly-iii` chart, mirroring the existing implementation in the `importer` chart (#112). This lets users expose Firefly III through the Kubernetes Gateway API as an alternative to Ingress.

### Changes
- New `templates/httproute.yaml`, gated on `httpRoute.enabled` (default `false` — no behavior change for existing users)
- `httpRoute` values block: `enabled`, `annotations`, `hostnames`, `parentRefs` (same shape as the `importer` chart)
- Bumped `firefly-iii` chart `1.9.17` → `1.10.0` and the matching `firefly-iii-stack` dependency pin
- READMEs regenerated with `helm-docs`

### Validation
- `helm template` with `httpRoute.enabled=false` renders no HTTPRoute; with `enabled=true` plus custom `hostnames` / `parentRefs` / `annotations` renders a valid HTTPRoute pointing at the service
- `helm lint` passes
- `ct lint --config ct.yaml --charts charts/firefly-iii` and `--charts charts/firefly-iii-stack` both pass

related: firefly-iii/firefly-iii#12208
