### PR TITLE
Support filters and additional rules on HTTPRoute

### DIFF
--- a/charts/firefly-iii-stack/Chart.yaml
+++ b/charts/firefly-iii-stack/Chart.yaml
@@ -4,14 +4,14 @@ description: Installs Firefly III stack (db, app, importer)
 home: https://github.com/firefly-iii/kubernetes
 icon: https://raw.githubusercontent.com/firefly-iii/firefly-iii/main/.github/assets/img/logo-small.png
 type: application
-version: 0.10.0
+version: 0.10.1
 dependencies:
   - name: firefly-db
     version: 0.2.10
     condition: firefly-db.enabled
     repository: file://../firefly-db
   - name: firefly-iii
-    version: 1.10.0
+    version: 1.10.1
     condition: firefly-iii.enabled
     repository: file://../firefly-iii
   - name: importer

--- a/charts/firefly-iii-stack/README.md
+++ b/charts/firefly-iii-stack/README.md
@@ -1,6 +1,6 @@
 # firefly-iii-stack
 
-![Version: 0.10.0](https://img.shields.io/badge/Version-0.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.10.1](https://img.shields.io/badge/Version-0.10.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Installs Firefly III stack (db, app, importer)
 **Homepage:** <https://github.com/firefly-iii/kubernetes>
@@ -17,7 +17,7 @@ Installs Firefly III stack (db, app, importer)
 | Repository | Name | Version |
 |------------|------|---------|
 | file://../firefly-db | firefly-db | 0.2.10 |
-| file://../firefly-iii | firefly-iii | 1.10.0 |
+| file://../firefly-iii | firefly-iii | 1.10.1 |
 | file://../importer | importer | 1.6.0 |
 
 ## Upgrading

--- a/charts/firefly-iii/Chart.yaml
+++ b/charts/firefly-iii/Chart.yaml
@@ -4,7 +4,7 @@ description: Installs Firefly III
 home: https://www.firefly-iii.org/
 icon: https://raw.githubusercontent.com/firefly-iii/firefly-iii/main/.github/assets/img/logo-small.png
 type: application
-version: 1.10.0
+version: 1.10.1
 # renovate: image=docker.io/fireflyiii/core
 appVersion: 6.5.9
 sources:

--- a/charts/firefly-iii/README.md
+++ b/charts/firefly-iii/README.md
@@ -1,6 +1,6 @@
 # firefly-iii
 
-![Version: 1.10.0](https://img.shields.io/badge/Version-1.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 6.5.9](https://img.shields.io/badge/AppVersion-6.5.9-informational?style=flat-square)
+![Version: 1.10.1](https://img.shields.io/badge/Version-1.10.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 6.5.9](https://img.shields.io/badge/AppVersion-6.5.9-informational?style=flat-square)
 
 Installs Firefly III
 **Homepage:** <https://www.firefly-iii.org/>
@@ -112,8 +112,10 @@ ingress:
 | fullnameOverride | string | `""` |  |
 | global.image.pullPolicy | string | `nil` | if set it will overwrite all pullPolicy |
 | global.image.registry | string | `nil` | if set it will overwrite all registry entries |
+| httpRoute.additionalRules | list | `[]` |  |
 | httpRoute.annotations | object | `{}` |  |
-| httpRoute.enabled | bool | `false` |  |
+| httpRoute.enabled | bool | `true` |  |
+| httpRoute.filters | list | `[]` |  |
 | httpRoute.hostnames | list | `[]` |  |
 | httpRoute.parentRefs | list | `[]` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |

--- a/charts/firefly-iii/templates/httproute.yaml
+++ b/charts/firefly-iii/templates/httproute.yaml
@@ -20,8 +20,14 @@ spec:
           name: {{ include "firefly-iii.fullname" . }}
           port: {{ .Values.service.port }}
           weight: 1
+      {{- with .Values.httpRoute.filters }}
+      filters: {{- toYaml . | nindent 8 }}
+      {{- end }}
       matches:
         - path:
             type: PathPrefix
             value: /
+    {{- with .Values.httpRoute.additionalRules }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 {{- end -}}

--- a/charts/firefly-iii/values.yaml
+++ b/charts/firefly-iii/values.yaml
@@ -157,6 +157,8 @@ httpRoute:
   annotations: {}
   hostnames: []
   parentRefs: []
+  filters: []
+  additionalRules: []
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
Extends the firefly-iii chart by adding options for filters and additional rules on the HTTPRoute introduced in #117. This is required to set up Remote-User authentication with e.g. Traefik & oauth2-proxy for integrating middleware and complex routing rules.

Both the original HTTPRoute (without using the newly introduced values) and the updated version have been successfully tested in a live K8s cluster.