### PR TITLE
chore(backups): Do not provision the backup PVC if backup config is not enabled

### DIFF
--- a/charts/firefly-db/Chart.yaml
+++ b/charts/firefly-db/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: firefly-db
 description: Installs a postgres db for Firefly III
 type: application
-version: 0.2.10
+version: 0.2.11
 sources:
   - https://github.com/firefly-iii/kubernetes/tree/main/charts/firefly-db
 maintainers:

--- a/charts/firefly-db/templates/firefly-backup-pvc.yml
+++ b/charts/firefly-db/templates/firefly-backup-pvc.yml
@@ -1,4 +1,4 @@
-{{- if and (eq .Values.backup.destination "pvc") (eq .Values.backup.pvc.existingClaim "") }}
+{{- if and .Values.configs.BACKUP_ENABLED (eq .Values.backup.destination "pvc") (eq .Values.backup.pvc.existingClaim "") }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/charts/firefly-iii-stack/Chart.yaml
+++ b/charts/firefly-iii-stack/Chart.yaml
@@ -4,10 +4,10 @@ description: Installs Firefly III stack (db, app, importer)
 home: https://github.com/firefly-iii/kubernetes
 icon: https://raw.githubusercontent.com/firefly-iii/firefly-iii/main/.github/assets/img/logo-small.png
 type: application
-version: 0.10.1
+version: 0.10.2
 dependencies:
   - name: firefly-db
-    version: 0.2.10
+    version: 0.2.11
     condition: firefly-db.enabled
     repository: file://../firefly-db
   - name: firefly-iii


### PR DESCRIPTION
<!--
Thank you for submitting new code to Firefly III, or any of the related projects. Please read the following rules carefully.

- Please do not submit solutions for problems that are not already reported in an issue.
- Unfortunately, Firefly III can't be your learning experience. If you're new to all of this, please open an issue first.
- Please do not open PRs to "discuss" possible solutions or to "get feedback" on your code. I simply don't have time for that.
- DO NOT include translated strings in your PR.
- PRs (or parts thereof) that only fix issues inside code comments will not be accepted.

If it feels necessary to open an issue first, please do so, before you open a PR.

See also: https://docs.firefly-iii.org/explanation/support/#contributing-code

-->
Changes in this pull request:

- Add a condition to provision the `backup-storage-claim` PVC only when the corresponding value `.Values.configs.BACKUP_ENABLED` is set to true.
